### PR TITLE
Update GH workflows for story 1958 and 1967

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -65,6 +65,11 @@ jobs:
         run: |
           docker run --rm -v ${{ github.workspace }}:/var/root/ ghcr.io/galasa-dev/galasabld-amd64:main template --releaseMetadata var/root/framework/release.yaml --releaseMetadata /var/root/extensions/release.yaml --releaseMetadata /var/root/managers/release.yaml --releaseMetadata /var/root/obr/release.yaml --template /var/root/isolated/full/pom.template --output /var/root/isolated/full/pom.xml --isolated
       
+      - name: Make directory to place build logs in
+        working-directory: ./isolated/full
+        run: |
+          mkdir isolated-build-logs
+          
       - name: Build Isolated pom.xml with maven
         working-directory: ./isolated/full
         env:
@@ -364,6 +369,11 @@ jobs:
         run: |
           docker run --rm -v ${{ github.workspace }}:/var/root/ ghcr.io/galasa-dev/galasabld-amd64:main template --releaseMetadata var/root/framework/release.yaml --releaseMetadata /var/root/extensions/release.yaml --releaseMetadata /var/root/managers/release.yaml --releaseMetadata /var/root/obr/release.yaml --template /var/root/isolated/mvp/pom.template --output /var/root/isolated/mvp/pom.xml --mvp
       
+      - name: Make directory to place build logs in
+        working-directory: ./isolated/mvp
+        run: |
+          mkdir mvp-build-logs
+
       - name: Build MVP pom.xml with maven
         working-directory: ./isolated/mvp
         env:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,15 +1,25 @@
 name: Main build
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
 
 env:
   REGISTRY: ghcr.io
   NAMESPACE: galasa-dev
-  IMAGE_TAG: main
-  
+  BRANCH: ${{ github.ref_name }}
+  ARGO_APP_BRANCH: gh # TODO: remove this parameter and just use env.BRANCH once we update development.galasa.dev/main with these workflows.
+
 jobs:
+  log-github-ref:
+    name: Log the GitHub ref this workflow is running on (Branch or tag that received dispatch)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log GitHub ref of workflow
+        run: |
+          echo "This workflow is running on GitHub ref ${{ env.BRANCH }}"
+
   build-isolated:
     name: Build Isolated
     runs-on: ubuntu-latest
@@ -18,25 +28,25 @@ jobs:
       - name: Checkout Framework
         uses: actions/checkout@v4
         with:
-          repository: ${{env.NAMESPACE}}/framework
+          repository: ${{ env.NAMESPACE }}/framework
           path: framework
 
       - name: Checkout Extensions
         uses: actions/checkout@v4
         with:
-          repository: ${{env.NAMESPACE}}/extensions
+          repository: ${{ env.NAMESPACE }}/extensions
           path: extensions
       
       - name: Checkout Managers
         uses: actions/checkout@v4
         with:
-          repository: ${{env.NAMESPACE}}/managers
+          repository: ${{ env.NAMESPACE }}/managers
           path: managers
 
       - name: Checkout OBR
         uses: actions/checkout@v4
         with:
-          repository: ${{env.NAMESPACE}}/obr
+          repository: ${{ env.NAMESPACE }}/obr
           path: obr
 
       - name: Checkout Isolated
@@ -47,13 +57,13 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'semeru'
           cache: maven
       
       - name:  Generate Isolated pom.xml
         run: |
-          docker run --rm -v ${{github.workspace}}:/var/root/ ghcr.io/${{env.NAMESPACE}}/galasabld-amd64:${{env.IMAGE_TAG}} template --releaseMetadata var/root/framework/release.yaml --releaseMetadata /var/root/extensions/release.yaml --releaseMetadata /var/root/managers/release.yaml --releaseMetadata /var/root/obr/release.yaml --template /var/root/isolated/full/pom.template --output /var/root/isolated/full/pom.xml --isolated
+          docker run --rm -v ${{ github.workspace }}:/var/root/ ghcr.io/galasa-dev/galasabld-amd64:main template --releaseMetadata var/root/framework/release.yaml --releaseMetadata /var/root/extensions/release.yaml --releaseMetadata /var/root/managers/release.yaml --releaseMetadata /var/root/obr/release.yaml --template /var/root/isolated/full/pom.template --output /var/root/isolated/full/pom.xml --isolated
       
       - name: Build Isolated pom.xml with maven
         working-directory: ./isolated/full
@@ -61,95 +71,102 @@ jobs:
           GITHUB_TOKEN_READ_PACKAGES_USERNAME: ${{ secrets.READ_GITHUB_PACKAGES_USERNAME }}
           GITHUB_TOKEN_READ_PACKAGES_PASSWORD: ${{ secrets.READ_GITHUB_PACKAGES_TOKEN }}
         run: |
-          mvn -f ${{github.workspace}}/isolated/full/pom.xml process-sources \
+          set -o pipefail
+          mvn -f ${{ github.workspace }}/isolated/full/pom.xml process-sources -X \
           -Dgalasa.target.repo=file:target/isolated/maven \
-          -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
-          -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
-          -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
+          -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/obr \
+          -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/simplatform \
+          -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/javadoc \
           -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           -Dgithub.token.read.packages.username=${{ env.GITHUB_TOKEN_READ_PACKAGES_USERNAME }} \
           -Dgithub.token.read.packages.password=${{ env.GITHUB_TOKEN_READ_PACKAGES_PASSWORD }} \
           --batch-mode --errors --fail-at-end \
-          --settings ${{ github.workspace }}/isolated/settings.xml
+          --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-pom.log
 
       - name: Build Isolated pom2.xml with maven
         working-directory: ./isolated/full
         run: |
-          mvn -f ${{github.workspace}}/isolated/full/pom2.xml process-sources \
+          set -o pipefail
+          mvn -f ${{ github.workspace }}/isolated/full/pom2.xml process-sources -X \
           -Dgalasa.target.repo=file:target/isolated/maven \
-          -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
-          -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
-          -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
+          -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/obr \
+          -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/simplatform \
+          -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/javadoc \
           -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
-          --settings ${{ github.workspace }}/isolated/settings.xml
+          --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-pom2.log
 
       - name: Build Isolated pom3.xml with maven
         working-directory: ./isolated/full
         run: |
-          mvn -f ${{github.workspace}}/isolated/full/pom3.xml process-sources \
+          set -o pipefail
+          mvn -f ${{ github.workspace }}/isolated/full/pom3.xml process-sources -X \
           -Dgalasa.target.repo=file:target/isolated/maven \
-          -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
-          -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
-          -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
+          -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/obr \
+          -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/simplatform \
+          -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/javadoc \
           -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
-          --settings ${{ github.workspace }}/isolated/settings.xml
+          --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-pom3.log
 
       - name: Build Isolated pom4.xml with maven
         working-directory: ./isolated/full
         run: |
-          mvn -f ${{github.workspace}}/isolated/full/pom4.xml process-sources \
+          set -o pipefail
+          mvn -f ${{ github.workspace }}/isolated/full/pom4.xml process-sources -X \
           -Dgalasa.target.repo=file:target/isolated/maven \
-          -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
-          -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
-          -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
+          -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/obr \
+          -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/simplatform \
+          -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/javadoc \
           -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
-          --settings ${{ github.workspace }}/isolated/settings.xml
+          --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-pom4.log
 
       - name: Build Isolated pom5.xml with maven
         working-directory: ./isolated/full
         run: |
-          mvn -f ${{github.workspace}}/isolated/full/pom5.xml process-sources \
+          set -o pipefail
+          mvn -f ${{ github.workspace }}/isolated/full/pom5.xml process-sources -X \
           -Dgalasa.target.repo=file:target/isolated/maven \
-          -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
-          -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
-          -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
+          -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/obr \
+          -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/simplatform \
+          -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/javadoc \
           -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
-          --settings ${{ github.workspace }}/isolated/settings.xml
+          --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-pom5.log
 
       - name: Build Isolated pom6.xml with maven
         working-directory: ./isolated/full
         run: |
-          mvn -f ${{github.workspace}}/isolated/full/pom6.xml process-sources \
+          set -o pipefail
+          mvn -f ${{ github.workspace }}/isolated/full/pom6.xml process-sources -X \
           -Dgalasa.target.repo=file:target/isolated/maven \
-          -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
-          -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
-          -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
+          -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/obr \
+          -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/simplatform \
+          -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/javadoc \
           -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
-          --settings ${{ github.workspace }}/isolated/settings.xml
+          --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-pom6.log
 
       - name: Build Isolated Javadoc with maven
         working-directory: ./isolated/full
         run: |
-          mvn -f ${{github.workspace}}/isolated/full/pomJavaDoc.xml process-sources \
+          set -o pipefail
+          mvn -f ${{ github.workspace }}/isolated/full/pomJavaDoc.xml process-sources -X \
           -Dgalasa.target.repo=file:target/isolated/maven \
-          -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
-          -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
-          -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
+          -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/obr \
+          -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/simplatform \
+          -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/javadoc \
           -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
-          --settings ${{ github.workspace }}/isolated/settings.xml
+          --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-javadoc.log
 
       - name: Build Isolated Docs with maven
         working-directory: ./isolated/full
@@ -157,43 +174,45 @@ jobs:
           GITHUB_TOKEN_READ_PACKAGES_USERNAME: ${{ secrets.READ_GITHUB_PACKAGES_USERNAME }}
           GITHUB_TOKEN_READ_PACKAGES_PASSWORD: ${{ secrets.READ_GITHUB_PACKAGES_TOKEN }}
         run: |
-          mvn -f ${{github.workspace}}/isolated/full/pomDocs.xml process-sources \
+          set -o pipefail
+          mvn -f ${{ github.workspace }}/isolated/full/pomDocs.xml process-sources -X \
           -Dgalasa.target.repo=file:target/isolated/maven \
-          -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
-          -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
-          -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
+          -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/obr \
+          -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/simplatform \
+          -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/javadoc \
           -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           -Dgithub.token.read.packages.username=${{ env.GITHUB_TOKEN_READ_PACKAGES_USERNAME }} \
           -Dgithub.token.read.packages.password=${{ env.GITHUB_TOKEN_READ_PACKAGES_PASSWORD }} \
           --batch-mode --errors --fail-at-end \
-          --settings ${{ github.workspace }}/isolated/settings.xml
+          --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-docs.log
 
       - name: Download galasactl binaries
         working-directory: ./isolated/full
         run: |
           mkdir bin && 
           cd bin && 
-          wget https://development.galasa.dev/main/binary/cli/galasactl-darwin-x86_64 &&
-          wget https://development.galasa.dev/main/binary/cli/galasactl-darwin-arm64 &&
-          wget https://development.galasa.dev/main/binary/cli/galasactl-linux-arm64 &&
-          wget https://development.galasa.dev/main/binary/cli/galasactl-linux-x86_64 &&
-          wget https://development.galasa.dev/main/binary/cli/galasactl-linux-s390x &&
-          wget https://development.galasa.dev/main/binary/cli/galasactl-windows-x86_64.exe &&
+          wget https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/binary/cli/galasactl-darwin-x86_64 &&
+          wget https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/binary/cli/galasactl-darwin-arm64 &&
+          wget https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/binary/cli/galasactl-linux-arm64 &&
+          wget https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/binary/cli/galasactl-linux-x86_64 &&
+          wget https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/binary/cli/galasactl-linux-s390x &&
+          wget https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/binary/cli/galasactl-windows-x86_64.exe &&
           cd ..
 
       - name: Build galasactl directory with maven
         working-directory: ./isolated/full
         run: |
-          mvn -f ${{github.workspace}}/isolated/full/pomGalasactl.xml validate \
+          set -o pipefail
+          mvn -f ${{ github.workspace }}/isolated/full/pomGalasactl.xml validate -X \
           -Dgalasa.target.repo=file:target/isolated/maven \
-          -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
-          -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
-          -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
+          -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/obr \
+          -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/simplatform \
+          -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/javadoc \
           -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
-          --settings ${{ github.workspace }}/isolated/settings.xml
+          --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-galasactl.log
 
       - name: Copy text files into Isolated
         working-directory: ./isolated/full
@@ -218,7 +237,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: ${{github.workspace}}/isolated/dockerfiles/dockerfile.isolated
+          file: ${{ github.workspace }}/isolated/dockerfiles/dockerfile.isolated
           push: true
           tags: ${{ steps.metadata-galasa-isolated.outputs.tags }}
           labels: ${{ steps.metadata-galasa-isolated.outputs.labels }}
@@ -236,7 +255,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: ${{github.workspace}}/isolated/dockerfiles/dockerfile.isolated
+          file: ${{ github.workspace }}/isolated/dockerfiles/dockerfile.isolated
           push: true
           tags: ${{ steps.metadata-galasa-isolated-tar.outputs.tags }}
           labels: ${{ steps.metadata-galasa-isolated-tar.outputs.labels }}
@@ -248,16 +267,24 @@ jobs:
       - name: Build Isolated zip with maven
         working-directory: ./isolated/full
         run: |
-          mvn -f ${{github.workspace}}/isolated/full/pomZip.xml deploy \
+          set -o pipefail
+          mvn -f ${{ github.workspace }}/isolated/full/pomZip.xml deploy -X \
           -Dgalasa.target.repo=file:target/isolated/maven \
-          -Dgalasa.release.repo=file:${{github.workspace}}/isolated/full/repo \
-          -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
-          -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
-          -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
+          -Dgalasa.release.repo=file:${{ github.workspace }}/isolated/full/repo \
+          -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/obr \
+          -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/simplatform \
+          -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/javadoc \
           -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
-          --settings ${{ github.workspace }}/isolated/settings.xml
+          --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-zip.log
+
+      - name: Upload Isolated Maven build logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: isolated-maven-build-logs
+          path: isolated-build-logs
 
       - name: Extract metadata for galasa-isolated-zip image
         id: metadata-galasa-isolated-zip
@@ -270,13 +297,26 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: ./isolated/full
-          file: ${{github.workspace}}/isolated/dockerfiles/dockerfile.isolatedzip
+          file: ${{ github.workspace }}/isolated/dockerfiles/dockerfile.isolatedzip
           push: true
           tags: ${{ steps.metadata-galasa-isolated-zip.outputs.tags }}
           labels: ${{ steps.metadata-galasa-isolated-zip.outputs.labels }}
           build-args: |
             baseVersion=latest
             dockerRepository=ghcr.io
+
+      - name: Recycle application in ArgoCD
+        env: 
+            ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_TOKEN }}
+        run: |
+            docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/galasa-dev/argocdcli:main app actions run ${{ env.ARGO_APP_BRANCH }}-maven-repos restart --kind Deployment --resource-name isolated-${{ env.ARGO_APP_BRANCH }} --server argocd.galasa.dev
+       
+      - name: Wait for application health in ArgoCD
+        env: 
+            ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_TOKEN }}
+        run: |
+            docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/galasa-dev/argocdcli:main app wait ${{ env.ARGO_APP_BRANCH }}-maven-repos --resource apps:Deployment:isolated-${{ env.ARGO_APP_BRANCH }} --health --server argocd.galasa.dev
+
 
   build-mvp:
     name: Build MVP
@@ -286,25 +326,25 @@ jobs:
       - name: Checkout Framework
         uses: actions/checkout@v4
         with:
-          repository: ${{env.NAMESPACE}}/framework
+          repository: ${{ env.NAMESPACE }}/framework
           path: framework
 
       - name: Checkout Extensions
         uses: actions/checkout@v4
         with:
-          repository: ${{env.NAMESPACE}}/extensions
+          repository: ${{ env.NAMESPACE }}/extensions
           path: extensions
       
       - name: Checkout Managers
         uses: actions/checkout@v4
         with:
-          repository: ${{env.NAMESPACE}}/managers
+          repository: ${{ env.NAMESPACE }}/managers
           path: managers
 
       - name: Checkout OBR
         uses: actions/checkout@v4
         with:
-          repository: ${{env.NAMESPACE}}/obr
+          repository: ${{ env.NAMESPACE }}/obr
           path: obr
 
       - name: Checkout Isolated
@@ -315,13 +355,13 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'semeru'
           cache: maven
       
       - name:  Generate MVP pom.xml
         run: |
-          docker run --rm -v ${{github.workspace}}:/var/root/ ghcr.io/${{env.NAMESPACE}}/galasabld-amd64:${{env.IMAGE_TAG}} template --releaseMetadata var/root/framework/release.yaml --releaseMetadata /var/root/extensions/release.yaml --releaseMetadata /var/root/managers/release.yaml --releaseMetadata /var/root/obr/release.yaml --template /var/root/isolated/mvp/pom.template --output /var/root/isolated/mvp/pom.xml --mvp
+          docker run --rm -v ${{ github.workspace }}:/var/root/ ghcr.io/galasa-dev/galasabld-amd64:main template --releaseMetadata var/root/framework/release.yaml --releaseMetadata /var/root/extensions/release.yaml --releaseMetadata /var/root/managers/release.yaml --releaseMetadata /var/root/obr/release.yaml --template /var/root/isolated/mvp/pom.template --output /var/root/isolated/mvp/pom.xml --mvp
       
       - name: Build MVP pom.xml with maven
         working-directory: ./isolated/mvp
@@ -329,95 +369,102 @@ jobs:
           GITHUB_TOKEN_READ_PACKAGES_USERNAME: ${{ secrets.READ_GITHUB_PACKAGES_USERNAME }}
           GITHUB_TOKEN_READ_PACKAGES_PASSWORD: ${{ secrets.READ_GITHUB_PACKAGES_TOKEN }}
         run: |
-          mvn -f ${{github.workspace}}/isolated/mvp/pom.xml process-sources \
+          set -o pipefail
+          mvn -f ${{ github.workspace }}/isolated/mvp/pom.xml process-sources -X \
           -Dgalasa.target.repo=file:target/isolated/maven \
-          -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
-          -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
-          -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
+          -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/obr \
+          -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/simplatform \
+          -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/javadoc \
           -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           -Dgithub.token.read.packages.username=${{ env.GITHUB_TOKEN_READ_PACKAGES_USERNAME }} \
           -Dgithub.token.read.packages.password=${{ env.GITHUB_TOKEN_READ_PACKAGES_PASSWORD }} \
           --batch-mode --errors --fail-at-end \
-          --settings ${{ github.workspace }}/isolated/settings.xml
+          --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-pom.log
 
       - name: Build MVP pom2.xml with maven
         working-directory: ./isolated/mvp
         run: |
-          mvn -f ${{github.workspace}}/isolated/mvp/pom2.xml process-sources \
+          set -o pipefail
+          mvn -f ${{ github.workspace }}/isolated/mvp/pom2.xml process-sources -X \
           -Dgalasa.target.repo=file:target/isolated/maven \
-          -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
-          -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
-          -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
+          -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/obr \
+          -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/simplatform \
+          -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/javadoc \
           -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
-          --settings ${{ github.workspace }}/isolated/settings.xml
+          --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-pom2.log
 
       - name: Build MVP pom3.xml with maven
         working-directory: ./isolated/mvp
         run: |
-          mvn -f ${{github.workspace}}/isolated/mvp/pom3.xml process-sources \
+          set -o pipefail
+          mvn -f ${{ github.workspace }}/isolated/mvp/pom3.xml process-sources -X \
           -Dgalasa.target.repo=file:target/isolated/maven \
-          -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
-          -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
-          -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
+          -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/obr \
+          -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/simplatform \
+          -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/javadoc \
           -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
-          --settings ${{ github.workspace }}/isolated/settings.xml
+          --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-pom3.log
 
       - name: Build MVP pom4.xml with maven
         working-directory: ./isolated/mvp
         run: |
-          mvn -f ${{github.workspace}}/isolated/mvp/pom4.xml process-sources \
+          set -o pipefail
+          mvn -f ${{ github.workspace }}/isolated/mvp/pom4.xml process-sources -X \
           -Dgalasa.target.repo=file:target/isolated/maven \
-          -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
-          -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
-          -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
+          -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/obr \
+          -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/simplatform \
+          -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/javadoc \
           -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
-          --settings ${{ github.workspace }}/isolated/settings.xml
+          --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-pom4.log
 
       - name: Build MVP pom5.xml with maven
         working-directory: ./isolated/mvp
         run: |
-          mvn -f ${{github.workspace}}/isolated/mvp/pom5.xml process-sources \
+          set -o pipefail
+          mvn -f ${{ github.workspace }}/isolated/mvp/pom5.xml process-sources -X \
           -Dgalasa.target.repo=file:target/isolated/maven \
-          -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
-          -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
-          -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
+          -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/obr \
+          -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/simplatform \
+          -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/javadoc \
           -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
-          --settings ${{ github.workspace }}/isolated/settings.xml
+          --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-pom5.log
 
       - name: Build MVP pom6.xml with maven
         working-directory: ./isolated/mvp
         run: |
-          mvn -f ${{github.workspace}}/isolated/mvp/pom6.xml process-sources \
+          set -o pipefail
+          mvn -f ${{ github.workspace }}/isolated/mvp/pom6.xml process-sources -X \
           -Dgalasa.target.repo=file:target/isolated/maven \
-          -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
-          -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
-          -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
+          -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/obr \
+          -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/simplatform \
+          -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/javadoc \
           -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
-          --settings ${{ github.workspace }}/isolated/settings.xml
+          --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-pom6.log
 
       - name: Build MVP Javadoc with maven
         working-directory: ./isolated/mvp
         run: |
-          mvn -f ${{github.workspace}}/isolated/mvp/pomJavaDoc.xml process-sources \
+          set -o pipefail
+          mvn -f ${{ github.workspace }}/isolated/mvp/pomJavaDoc.xml process-sources -X \
           -Dgalasa.target.repo=file:target/isolated/maven \
-          -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
-          -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
-          -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
+          -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/obr \
+          -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/simplatform \
+          -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/javadoc \
           -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
-          --settings ${{ github.workspace }}/isolated/settings.xml
+          --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-javadoc.log
 
       - name: Build MVP Docs with maven
         working-directory: ./isolated/mvp
@@ -425,43 +472,45 @@ jobs:
           GITHUB_TOKEN_READ_PACKAGES_USERNAME: ${{ secrets.READ_GITHUB_PACKAGES_USERNAME }}
           GITHUB_TOKEN_READ_PACKAGES_PASSWORD: ${{ secrets.READ_GITHUB_PACKAGES_TOKEN }}
         run: |
-          mvn -f ${{github.workspace}}/isolated/mvp/pomDocs.xml process-sources \
+          set -o pipefail
+          mvn -f ${{ github.workspace }}/isolated/mvp/pomDocs.xml process-sources -X \
           -Dgalasa.target.repo=file:target/isolated/maven \
-          -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
-          -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
-          -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
+          -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/obr \
+          -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/simplatform \
+          -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/javadoc \
           -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           -Dgithub.token.read.packages.username=${{ env.GITHUB_TOKEN_READ_PACKAGES_USERNAME }} \
           -Dgithub.token.read.packages.password=${{ env.GITHUB_TOKEN_READ_PACKAGES_PASSWORD }} \
           --batch-mode --errors --fail-at-end \
-          --settings ${{ github.workspace }}/isolated/settings.xml
+          --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-docs.log
 
       - name: Download galasactl binaries
         working-directory: ./isolated/mvp
         run: |
           mkdir bin && 
           cd bin && 
-          wget https://development.galasa.dev/gh/binary/cli/galasactl-darwin-x86_64 &&
-          wget https://development.galasa.dev/gh/binary/cli/galasactl-darwin-arm64 &&
-          wget https://development.galasa.dev/gh/binary/cli/galasactl-linux-arm64 &&
-          wget https://development.galasa.dev/gh/binary/cli/galasactl-linux-x86_64 &&
-          wget https://development.galasa.dev/gh/binary/cli/galasactl-linux-s390x &&
-          wget https://development.galasa.dev/gh/binary/cli/galasactl-windows-x86_64.exe &&
+          wget https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/binary/cli/galasactl-darwin-x86_64 &&
+          wget https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/binary/cli/galasactl-darwin-arm64 &&
+          wget https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/binary/cli/galasactl-linux-arm64 &&
+          wget https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/binary/cli/galasactl-linux-x86_64 &&
+          wget https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/binary/cli/galasactl-linux-s390x &&
+          wget https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/binary/cli/galasactl-windows-x86_64.exe &&
           cd ..
 
       - name: Build galasactl directory with maven
         working-directory: ./isolated/mvp
         run: |
-          mvn -f ${{github.workspace}}/isolated/mvp/pomGalasactl.xml validate \
+          set -o pipefail
+          mvn -f ${{ github.workspace }}/isolated/mvp/pomGalasactl.xml validate -X \
           -Dgalasa.target.repo=file:target/isolated/maven \
-          -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
-          -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
-          -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
+          -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/obr \
+          -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/simplatform \
+          -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/javadoc \
           -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
-          --settings ${{ github.workspace }}/isolated/settings.xml
+          --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-galasactl.log
 
       - name: Copy text files into MVP
         working-directory: ./isolated/mvp
@@ -486,7 +535,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: ${{github.workspace}}/isolated/dockerfiles/dockerfile.isolated
+          file: ${{ github.workspace }}/isolated/dockerfiles/dockerfile.isolated
           push: true
           tags: ${{ steps.metadata-galasa-mvp.outputs.tags }}
           labels: ${{ steps.metadata-galasa-mvp.outputs.labels }}
@@ -504,7 +553,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: ${{github.workspace}}/isolated/dockerfiles/dockerfile.isolated
+          file: ${{ github.workspace }}/isolated/dockerfiles/dockerfile.isolated
           push: true
           tags: ${{ steps.metadata-galasa-mvp-tar.outputs.tags }}
           labels: ${{ steps.metadata-galasa-mvp-tar.outputs.labels }}
@@ -516,16 +565,24 @@ jobs:
       - name: Build MVP zip with maven
         working-directory: ./isolated/mvp
         run: |
-          mvn -f ${{github.workspace}}/isolated/mvp/pomZip.xml deploy \
+          set -o pipefail
+          mvn -f ${{ github.workspace }}/isolated/mvp/pomZip.xml deploy -X \
           -Dgalasa.target.repo=file:target/isolated/maven \
-          -Dgalasa.release.repo=file:${{github.workspace}}/isolated/mvp/repo \
-          -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
-          -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
-          -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
+          -Dgalasa.release.repo=file:${{ github.workspace }}/isolated/mvp/repo \
+          -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/obr \
+          -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/simplatform \
+          -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.ARGO_APP_BRANCH }}/maven-repo/javadoc \
           -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
-          --settings ${{ github.workspace }}/isolated/settings.xml
+          --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-zip.log
+
+      - name: Upload MVP Maven build logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mvp-maven-build-logs
+          path: mvp-build-logs
 
       - name: Extract metadata for galasa-mvp-zip image
         id: metadata-galasa-mvp-zip
@@ -538,11 +595,22 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: ./isolated/mvp
-          file: ${{github.workspace}}/isolated/dockerfiles/dockerfile.isolatedzip
+          file: ${{ github.workspace }}/isolated/dockerfiles/dockerfile.isolatedzip
           push: true
           tags: ${{ steps.metadata-galasa-mvp-zip.outputs.tags }}
           labels: ${{ steps.metadata-galasa-mvp-zip.outputs.labels }}
           build-args: |
             baseVersion=latest
             dockerRepository=ghcr.io
-      
+
+      - name: Recycle application in ArgoCD
+        env: 
+            ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_TOKEN }}
+        run: |
+            docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/galasa-dev/argocdcli:main app actions run ${{ env.ARGO_APP_BRANCH }}-maven-repos restart --kind Deployment --resource-name mvp-${{ env.ARGO_APP_BRANCH }} --server argocd.galasa.dev
+       
+      - name: Wait for application health in ArgoCD
+        env: 
+            ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_TOKEN }}
+        run: |
+            docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/galasa-dev/argocdcli:main app wait ${{ env.ARGO_APP_BRANCH }}-maven-repos --resource apps:Deployment:mvp-${{ env.ARGO_APP_BRANCH }} --health --server argocd.galasa.dev

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -280,11 +280,12 @@ jobs:
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-zip.log
 
       - name: Upload Isolated Maven build logs
-        if: always()
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: isolated-maven-build-logs
           path: isolated-build-logs
+          retention-days: 7
 
       - name: Extract metadata for galasa-isolated-zip image
         id: metadata-galasa-isolated-zip
@@ -578,11 +579,12 @@ jobs:
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-zip.log
 
       - name: Upload MVP Maven build logs
-        if: always()
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: mvp-maven-build-logs
           path: mvp-build-logs
+          retention-days: 7
 
       - name: Extract metadata for galasa-mvp-zip image
         id: metadata-galasa-mvp-zip

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -61,6 +61,7 @@ jobs:
           GITHUB_TOKEN_READ_PACKAGES_USERNAME: ${{ secrets.READ_GITHUB_PACKAGES_USERNAME }}
           GITHUB_TOKEN_READ_PACKAGES_PASSWORD: ${{ secrets.READ_GITHUB_PACKAGES_TOKEN }}
         run: |
+          set -o pipefail
           mvn -f ${{ github.workspace }}/isolated/full/pom.xml process-sources -X \
           -Dgpg.skip=true \
           -Dgalasa.target.repo=file:target/isolated/maven \
@@ -72,11 +73,12 @@ jobs:
           -Dgithub.token.read.packages.username=${{ env.GITHUB_TOKEN_READ_PACKAGES_USERNAME }} \
           -Dgithub.token.read.packages.password=${{ env.GITHUB_TOKEN_READ_PACKAGES_PASSWORD }} \
           --batch-mode --errors --fail-at-end \
-          --settings ${{ github.workspace }}/isolated/settings.xml
+          --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-pom.log
 
       - name: Build Isolated pom2.xml with maven
         working-directory: ./isolated/full
         run: |
+          set -o pipefail
           mvn -f ${{ github.workspace }}/isolated/full/pom2.xml process-sources -X \
           -Dgpg.skip=true \
           -Dgalasa.target.repo=file:target/isolated/maven \
@@ -86,11 +88,12 @@ jobs:
           -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
-          --settings ${{ github.workspace }}/isolated/settings.xml
+          --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-pom2.log
 
       - name: Build Isolated pom3.xml with maven
         working-directory: ./isolated/full
         run: |
+          set -o pipefail
           mvn -f ${{ github.workspace }}/isolated/full/pom3.xml process-sources -X \
           -Dgpg.skip=true \
           -Dgalasa.target.repo=file:target/isolated/maven \
@@ -100,11 +103,12 @@ jobs:
           -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
-          --settings ${{ github.workspace }}/isolated/settings.xml
+          --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-pom3.log
 
       - name: Build Isolated pom4.xml with maven
         working-directory: ./isolated/full
         run: |
+          set -o pipefail
           mvn -f ${{ github.workspace }}/isolated/full/pom4.xml process-sources -X \
           -Dgpg.skip=true \
           -Dgalasa.target.repo=file:target/isolated/maven \
@@ -114,11 +118,12 @@ jobs:
           -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
-          --settings ${{ github.workspace }}/isolated/settings.xml
+          --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-pom4.log
 
       - name: Build Isolated pom5.xml with maven
         working-directory: ./isolated/full
         run: |
+          set -o pipefail
           mvn -f ${{ github.workspace }}/isolated/full/pom5.xml process-sources -X \
           -Dgpg.skip=true \
           -Dgalasa.target.repo=file:target/isolated/maven \
@@ -128,11 +133,12 @@ jobs:
           -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
-          --settings ${{ github.workspace }}/isolated/settings.xml
+          --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-pom5.log
 
       - name: Build Isolated pom6.xml with maven
         working-directory: ./isolated/full
         run: |
+          set -o pipefail
           mvn -f ${{ github.workspace }}/isolated/full/pom6.xml process-sources -X \
           -Dgpg.skip=true \
           -Dgalasa.target.repo=file:target/isolated/maven \
@@ -142,11 +148,12 @@ jobs:
           -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
-          --settings ${{ github.workspace }}/isolated/settings.xml
+          --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-pom6.log
 
       - name: Build Isolated Javadoc with maven
         working-directory: ./isolated/full
         run: |
+          set -o pipefail
           mvn -f ${{ github.workspace }}/isolated/full/pomJavaDoc.xml process-sources -X \
           -Dgpg.skip=true \
           -Dgalasa.target.repo=file:target/isolated/maven \
@@ -156,7 +163,7 @@ jobs:
           -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
-          --settings ${{ github.workspace }}/isolated/settings.xml
+          --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-javadoc.log
 
       - name: Build Isolated Docs with maven
         working-directory: ./isolated/full
@@ -164,6 +171,7 @@ jobs:
           GITHUB_TOKEN_READ_PACKAGES_USERNAME: ${{ secrets.READ_GITHUB_PACKAGES_USERNAME }}
           GITHUB_TOKEN_READ_PACKAGES_PASSWORD: ${{ secrets.READ_GITHUB_PACKAGES_TOKEN }}
         run: |
+          set -o pipefail
           mvn -f ${{ github.workspace }}/isolated/full/pomDocs.xml process-sources -X \
           -Dgpg.skip=true \
           -Dgalasa.target.repo=file:target/isolated/maven \
@@ -175,7 +183,7 @@ jobs:
           -Dgithub.token.read.packages.username=${{ env.GITHUB_TOKEN_READ_PACKAGES_USERNAME }} \
           -Dgithub.token.read.packages.password=${{ env.GITHUB_TOKEN_READ_PACKAGES_PASSWORD }} \
           --batch-mode --errors --fail-at-end \
-          --settings ${{ github.workspace }}/isolated/settings.xml
+          --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-docs.log
 
       - name: Download galasactl binaries
         working-directory: ./isolated/full
@@ -193,6 +201,7 @@ jobs:
       - name: Build galasactl directory with maven
         working-directory: ./isolated/full
         run: |
+          set -o pipefail
           mvn -f ${{ github.workspace }}/isolated/full/pomGalasactl.xml validate -X \
           -Dgpg.skip=true \
           -Dgalasa.target.repo=file:target/isolated/maven \
@@ -202,7 +211,7 @@ jobs:
           -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
-          --settings ${{ github.workspace }}/isolated/settings.xml
+          --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-galasactl.log
 
       - name: Copy text files into Isolated
         working-directory: ./isolated/full
@@ -234,6 +243,7 @@ jobs:
       - name: Build Isolated zip with maven
         working-directory: ./isolated/full
         run: |
+          set -o pipefail
           mvn -f ${{ github.workspace }}/isolated/full/pomZip.xml deploy -X \
           -Dgpg.skip=true \
           -Dgalasa.target.repo=file:target/isolated/maven \
@@ -244,7 +254,15 @@ jobs:
           -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
-          --settings ${{ github.workspace }}/isolated/settings.xml
+          --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-zip.log
+
+      - name: Upload Isolated Maven build logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: isolated-maven-build-logs
+          path: isolated-build-logs
+          retention-days: 7
 
       - name: Build Docker image for Isolated zip
         uses: docker/build-push-action@v5
@@ -308,6 +326,7 @@ jobs:
           GITHUB_TOKEN_READ_PACKAGES_USERNAME: ${{ secrets.READ_GITHUB_PACKAGES_USERNAME }}
           GITHUB_TOKEN_READ_PACKAGES_PASSWORD: ${{ secrets.READ_GITHUB_PACKAGES_TOKEN }}
         run: |
+          set -o pipefail
           mvn -f ${{ github.workspace }}/isolated/mvp/pom.xml process-sources -X \
           -Dgpg.skip=true \
           -Dgalasa.target.repo=file:target/isolated/maven \
@@ -319,11 +338,12 @@ jobs:
           -Dgithub.token.read.packages.username=${{ env.GITHUB_TOKEN_READ_PACKAGES_USERNAME }} \
           -Dgithub.token.read.packages.password=${{ env.GITHUB_TOKEN_READ_PACKAGES_PASSWORD }} \
           --batch-mode --errors --fail-at-end \
-          --settings ${{ github.workspace }}/isolated/settings.xml
+          --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-pom.log
 
       - name: Build MVP pom2.xml with maven
         working-directory: ./isolated/mvp
         run: |
+          set -o pipefail
           mvn -f ${{ github.workspace }}/isolated/mvp/pom2.xml process-sources -X \
           -Dgpg.skip=true \
           -Dgalasa.target.repo=file:target/isolated/maven \
@@ -333,11 +353,12 @@ jobs:
           -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
-          --settings ${{ github.workspace }}/isolated/settings.xml
+          --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-pom2.log
 
       - name: Build MVP pom3.xml with maven
         working-directory: ./isolated/mvp
         run: |
+          set -o pipefail
           mvn -f ${{ github.workspace }}/isolated/mvp/pom3.xml process-sources -X \
           -Dgpg.skip=true \
           -Dgalasa.target.repo=file:target/isolated/maven \
@@ -347,11 +368,12 @@ jobs:
           -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
-          --settings ${{ github.workspace }}/isolated/settings.xml
+          --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-pom3.log
 
       - name: Build MVP pom4.xml with maven
         working-directory: ./isolated/mvp
         run: |
+          set -o pipefail
           mvn -f ${{ github.workspace }}/isolated/mvp/pom4.xml process-sources -X \
           -Dgpg.skip=true \
           -Dgalasa.target.repo=file:target/isolated/maven \
@@ -361,11 +383,12 @@ jobs:
           -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
-          --settings ${{ github.workspace }}/isolated/settings.xml
+          --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-pom4.log
 
       - name: Build MVP pom5.xml with maven
         working-directory: ./isolated/mvp
         run: |
+          set -o pipefail
           mvn -f ${{ github.workspace }}/isolated/mvp/pom5.xml process-sources -X \
           -Dgpg.skip=true \
           -Dgalasa.target.repo=file:target/isolated/maven \
@@ -375,11 +398,12 @@ jobs:
           -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
-          --settings ${{ github.workspace }}/isolated/settings.xml
+          --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-pom5.log
 
       - name: Build MVP pom6.xml with maven
         working-directory: ./isolated/mvp
         run: |
+          set -o pipefail
           mvn -f ${{ github.workspace }}/isolated/mvp/pom6.xml process-sources -X \
           -Dgpg.skip=true \
           -Dgalasa.target.repo=file:target/isolated/maven \
@@ -389,11 +413,12 @@ jobs:
           -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
-          --settings ${{ github.workspace }}/isolated/settings.xml
+          --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-pom6.log
 
       - name: Build MVP Javadoc with maven
         working-directory: ./isolated/mvp
         run: |
+          set -o pipefail
           mvn -f ${{ github.workspace }}/isolated/mvp/pomJavaDoc.xml process-sources -X \
           -Dgpg.skip=true \
           -Dgalasa.target.repo=file:target/isolated/maven \
@@ -403,7 +428,7 @@ jobs:
           -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
-          --settings ${{ github.workspace }}/isolated/settings.xml
+          --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-javadoc.log
 
       - name: Build MVP Docs with maven
         working-directory: ./isolated/mvp
@@ -411,6 +436,7 @@ jobs:
           GITHUB_TOKEN_READ_PACKAGES_USERNAME: ${{ secrets.READ_GITHUB_PACKAGES_USERNAME }}
           GITHUB_TOKEN_READ_PACKAGES_PASSWORD: ${{ secrets.READ_GITHUB_PACKAGES_TOKEN }}
         run: |
+          set -o pipefail
           mvn -f ${{ github.workspace }}/isolated/mvp/pomDocs.xml process-sources -X \
           -Dgpg.skip=true \
           -Dgalasa.target.repo=file:target/isolated/maven \
@@ -422,7 +448,7 @@ jobs:
           -Dgithub.token.read.packages.username=${{ env.GITHUB_TOKEN_READ_PACKAGES_USERNAME }} \
           -Dgithub.token.read.packages.password=${{ env.GITHUB_TOKEN_READ_PACKAGES_PASSWORD }} \
           --batch-mode --errors --fail-at-end \
-          --settings ${{ github.workspace }}/isolated/settings.xml
+          --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-docs.log
 
       - name: Download galasactl binaries
         working-directory: ./isolated/mvp
@@ -440,6 +466,7 @@ jobs:
       - name: Build galasactl directory with maven
         working-directory: ./isolated/mvp
         run: |
+          set -o pipefail
           mvn -f ${{ github.workspace }}/isolated/mvp/pomGalasactl.xml validate -X \
           -Dgpg.skip=true \
           -Dgalasa.target.repo=file:target/isolated/maven \
@@ -449,7 +476,7 @@ jobs:
           -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
-          --settings ${{ github.workspace }}/isolated/settings.xml
+          --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-galasactl.log
 
       - name: Copy text files into MVP
         working-directory: ./isolated/mvp
@@ -481,6 +508,7 @@ jobs:
       - name: Build MVP zip with maven
         working-directory: ./isolated/mvp
         run: |
+          set -o pipefail
           mvn -f ${{ github.workspace }}/isolated/mvp/pomZip.xml deploy -X \
           -Dgpg.skip=true \
           -Dgalasa.target.repo=file:target/isolated/maven \
@@ -491,7 +519,15 @@ jobs:
           -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
-          --settings ${{ github.workspace }}/isolated/settings.xml
+          --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-zip.log
+
+      - name: Upload MVP Maven build logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mvp-maven-build-logs
+          path: mvp-build-logs
+          retention-days: 7
 
       - name: Build Docker image for MVP zip
         uses: docker/build-push-action@v5

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -18,25 +18,25 @@ jobs:
       - name: Checkout Framework
         uses: actions/checkout@v4
         with:
-          repository: ${{env.NAMESPACE}}/framework
+          repository: ${{ env.NAMESPACE }}/framework
           path: framework
 
       - name: Checkout Extensions
         uses: actions/checkout@v4
         with:
-          repository: ${{env.NAMESPACE}}/extensions
+          repository: ${{ env.NAMESPACE }}/extensions
           path: extensions
       
       - name: Checkout Managers
         uses: actions/checkout@v4
         with:
-          repository: ${{env.NAMESPACE}}/managers
+          repository: ${{ env.NAMESPACE }}/managers
           path: managers
 
       - name: Checkout OBR
         uses: actions/checkout@v4
         with:
-          repository: ${{env.NAMESPACE}}/obr
+          repository: ${{ env.NAMESPACE }}/obr
           path: obr
 
       - name: Checkout Isolated
@@ -47,13 +47,13 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'semeru'
           cache: maven
       
       - name:  Generate Isolated pom.xml
         run: |
-          docker run --rm -v ${{github.workspace}}:/var/root/ ghcr.io/${{env.NAMESPACE}}/galasabld-amd64:${{env.IMAGE_TAG}} template --releaseMetadata var/root/framework/release.yaml --releaseMetadata /var/root/extensions/release.yaml --releaseMetadata /var/root/managers/release.yaml --releaseMetadata /var/root/obr/release.yaml --template /var/root/isolated/full/pom.template --output /var/root/isolated/full/pom.xml --isolated
+          docker run --rm -v ${{ github.workspace }}:/var/root/ ghcr.io/galasa-dev/galasabld-amd64:main template --releaseMetadata var/root/framework/release.yaml --releaseMetadata /var/root/extensions/release.yaml --releaseMetadata /var/root/managers/release.yaml --releaseMetadata /var/root/obr/release.yaml --template /var/root/isolated/full/pom.template --output /var/root/isolated/full/pom.xml --isolated
       
       - name: Build Isolated pom.xml with maven
         working-directory: ./isolated/full
@@ -61,7 +61,7 @@ jobs:
           GITHUB_TOKEN_READ_PACKAGES_USERNAME: ${{ secrets.READ_GITHUB_PACKAGES_USERNAME }}
           GITHUB_TOKEN_READ_PACKAGES_PASSWORD: ${{ secrets.READ_GITHUB_PACKAGES_TOKEN }}
         run: |
-          mvn -f ${{github.workspace}}/isolated/full/pom.xml process-sources \
+          mvn -f ${{ github.workspace }}/isolated/full/pom.xml process-sources -X \
           -Dgpg.skip=true \
           -Dgalasa.target.repo=file:target/isolated/maven \
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
@@ -77,7 +77,7 @@ jobs:
       - name: Build Isolated pom2.xml with maven
         working-directory: ./isolated/full
         run: |
-          mvn -f ${{github.workspace}}/isolated/full/pom2.xml process-sources \
+          mvn -f ${{ github.workspace }}/isolated/full/pom2.xml process-sources -X \
           -Dgpg.skip=true \
           -Dgalasa.target.repo=file:target/isolated/maven \
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
@@ -91,7 +91,7 @@ jobs:
       - name: Build Isolated pom3.xml with maven
         working-directory: ./isolated/full
         run: |
-          mvn -f ${{github.workspace}}/isolated/full/pom3.xml process-sources \
+          mvn -f ${{ github.workspace }}/isolated/full/pom3.xml process-sources -X \
           -Dgpg.skip=true \
           -Dgalasa.target.repo=file:target/isolated/maven \
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
@@ -105,7 +105,7 @@ jobs:
       - name: Build Isolated pom4.xml with maven
         working-directory: ./isolated/full
         run: |
-          mvn -f ${{github.workspace}}/isolated/full/pom4.xml process-sources \
+          mvn -f ${{ github.workspace }}/isolated/full/pom4.xml process-sources -X \
           -Dgpg.skip=true \
           -Dgalasa.target.repo=file:target/isolated/maven \
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
@@ -119,7 +119,7 @@ jobs:
       - name: Build Isolated pom5.xml with maven
         working-directory: ./isolated/full
         run: |
-          mvn -f ${{github.workspace}}/isolated/full/pom5.xml process-sources \
+          mvn -f ${{ github.workspace }}/isolated/full/pom5.xml process-sources -X \
           -Dgpg.skip=true \
           -Dgalasa.target.repo=file:target/isolated/maven \
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
@@ -133,7 +133,7 @@ jobs:
       - name: Build Isolated pom6.xml with maven
         working-directory: ./isolated/full
         run: |
-          mvn -f ${{github.workspace}}/isolated/full/pom6.xml process-sources \
+          mvn -f ${{ github.workspace }}/isolated/full/pom6.xml process-sources -X \
           -Dgpg.skip=true \
           -Dgalasa.target.repo=file:target/isolated/maven \
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
@@ -147,7 +147,7 @@ jobs:
       - name: Build Isolated Javadoc with maven
         working-directory: ./isolated/full
         run: |
-          mvn -f ${{github.workspace}}/isolated/full/pomJavaDoc.xml process-sources \
+          mvn -f ${{ github.workspace }}/isolated/full/pomJavaDoc.xml process-sources -X \
           -Dgpg.skip=true \
           -Dgalasa.target.repo=file:target/isolated/maven \
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
@@ -164,7 +164,7 @@ jobs:
           GITHUB_TOKEN_READ_PACKAGES_USERNAME: ${{ secrets.READ_GITHUB_PACKAGES_USERNAME }}
           GITHUB_TOKEN_READ_PACKAGES_PASSWORD: ${{ secrets.READ_GITHUB_PACKAGES_TOKEN }}
         run: |
-          mvn -f ${{github.workspace}}/isolated/full/pomDocs.xml process-sources \
+          mvn -f ${{ github.workspace }}/isolated/full/pomDocs.xml process-sources -X \
           -Dgpg.skip=true \
           -Dgalasa.target.repo=file:target/isolated/maven \
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
@@ -193,7 +193,7 @@ jobs:
       - name: Build galasactl directory with maven
         working-directory: ./isolated/full
         run: |
-          mvn -f ${{github.workspace}}/isolated/full/pomGalasactl.xml validate \
+          mvn -f ${{ github.workspace }}/isolated/full/pomGalasactl.xml validate -X \
           -Dgpg.skip=true \
           -Dgalasa.target.repo=file:target/isolated/maven \
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
@@ -213,7 +213,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: ${{github.workspace}}/isolated/dockerfiles/dockerfile.isolated
+          file: ${{ github.workspace }}/isolated/dockerfiles/dockerfile.isolated
           load: true
           tags: galasa-isolated:test
           build-args: |
@@ -223,7 +223,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: ${{github.workspace}}/isolated/dockerfiles/dockerfile.isolated
+          file: ${{ github.workspace }}/isolated/dockerfiles/dockerfile.isolated
           load: true
           tags: galasa-isolated-tar:test
           build-args: |
@@ -234,10 +234,10 @@ jobs:
       - name: Build Isolated zip with maven
         working-directory: ./isolated/full
         run: |
-          mvn -f ${{github.workspace}}/isolated/full/pomZip.xml deploy \
+          mvn -f ${{ github.workspace }}/isolated/full/pomZip.xml deploy -X \
           -Dgpg.skip=true \
           -Dgalasa.target.repo=file:target/isolated/maven \
-          -Dgalasa.release.repo=file:${{github.workspace}}/isolated/full/repo \
+          -Dgalasa.release.repo=file:${{ github.workspace }}/isolated/full/repo \
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
@@ -250,7 +250,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: ./isolated/full
-          file: ${{github.workspace}}/isolated/dockerfiles/dockerfile.isolatedzip
+          file: ${{ github.workspace }}/isolated/dockerfiles/dockerfile.isolatedzip
           load: true
           tags: galasa-isolated-zip:test
           build-args: |
@@ -265,25 +265,25 @@ jobs:
       - name: Checkout Framework
         uses: actions/checkout@v4
         with:
-          repository: ${{env.NAMESPACE}}/framework
+          repository: ${{ env.NAMESPACE }}/framework
           path: framework
 
       - name: Checkout Extensions
         uses: actions/checkout@v4
         with:
-          repository: ${{env.NAMESPACE}}/extensions
+          repository: ${{ env.NAMESPACE }}/extensions
           path: extensions
       
       - name: Checkout Managers
         uses: actions/checkout@v4
         with:
-          repository: ${{env.NAMESPACE}}/managers
+          repository: ${{ env.NAMESPACE }}/managers
           path: managers
 
       - name: Checkout OBR
         uses: actions/checkout@v4
         with:
-          repository: ${{env.NAMESPACE}}/obr
+          repository: ${{ env.NAMESPACE }}/obr
           path: obr
 
       - name: Checkout Isolated
@@ -294,13 +294,13 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'semeru'
           cache: maven
       
       - name:  Generate MVP pom.xml
         run: |
-          docker run --rm -v ${{github.workspace}}:/var/root/ ghcr.io/${{env.NAMESPACE}}/galasabld-amd64:${{env.IMAGE_TAG}} template --releaseMetadata var/root/framework/release.yaml --releaseMetadata /var/root/extensions/release.yaml --releaseMetadata /var/root/managers/release.yaml --releaseMetadata /var/root/obr/release.yaml --template /var/root/isolated/mvp/pom.template --output /var/root/isolated/mvp/pom.xml --mvp
+          docker run --rm -v ${{ github.workspace }}:/var/root/ ghcr.io/galasa-dev/galasabld-amd64:main template --releaseMetadata var/root/framework/release.yaml --releaseMetadata /var/root/extensions/release.yaml --releaseMetadata /var/root/managers/release.yaml --releaseMetadata /var/root/obr/release.yaml --template /var/root/isolated/mvp/pom.template --output /var/root/isolated/mvp/pom.xml --mvp
       
       - name: Build MVP pom.xml with maven
         working-directory: ./isolated/mvp
@@ -308,7 +308,7 @@ jobs:
           GITHUB_TOKEN_READ_PACKAGES_USERNAME: ${{ secrets.READ_GITHUB_PACKAGES_USERNAME }}
           GITHUB_TOKEN_READ_PACKAGES_PASSWORD: ${{ secrets.READ_GITHUB_PACKAGES_TOKEN }}
         run: |
-          mvn -f ${{github.workspace}}/isolated/mvp/pom.xml process-sources \
+          mvn -f ${{ github.workspace }}/isolated/mvp/pom.xml process-sources -X \
           -Dgpg.skip=true \
           -Dgalasa.target.repo=file:target/isolated/maven \
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
@@ -324,7 +324,7 @@ jobs:
       - name: Build MVP pom2.xml with maven
         working-directory: ./isolated/mvp
         run: |
-          mvn -f ${{github.workspace}}/isolated/mvp/pom2.xml process-sources \
+          mvn -f ${{ github.workspace }}/isolated/mvp/pom2.xml process-sources -X \
           -Dgpg.skip=true \
           -Dgalasa.target.repo=file:target/isolated/maven \
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
@@ -338,7 +338,7 @@ jobs:
       - name: Build MVP pom3.xml with maven
         working-directory: ./isolated/mvp
         run: |
-          mvn -f ${{github.workspace}}/isolated/mvp/pom3.xml process-sources \
+          mvn -f ${{ github.workspace }}/isolated/mvp/pom3.xml process-sources -X \
           -Dgpg.skip=true \
           -Dgalasa.target.repo=file:target/isolated/maven \
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
@@ -352,7 +352,7 @@ jobs:
       - name: Build MVP pom4.xml with maven
         working-directory: ./isolated/mvp
         run: |
-          mvn -f ${{github.workspace}}/isolated/mvp/pom4.xml process-sources \
+          mvn -f ${{ github.workspace }}/isolated/mvp/pom4.xml process-sources -X \
           -Dgpg.skip=true \
           -Dgalasa.target.repo=file:target/isolated/maven \
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
@@ -366,7 +366,7 @@ jobs:
       - name: Build MVP pom5.xml with maven
         working-directory: ./isolated/mvp
         run: |
-          mvn -f ${{github.workspace}}/isolated/mvp/pom5.xml process-sources \
+          mvn -f ${{ github.workspace }}/isolated/mvp/pom5.xml process-sources -X \
           -Dgpg.skip=true \
           -Dgalasa.target.repo=file:target/isolated/maven \
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
@@ -380,7 +380,7 @@ jobs:
       - name: Build MVP pom6.xml with maven
         working-directory: ./isolated/mvp
         run: |
-          mvn -f ${{github.workspace}}/isolated/mvp/pom6.xml process-sources \
+          mvn -f ${{ github.workspace }}/isolated/mvp/pom6.xml process-sources -X \
           -Dgpg.skip=true \
           -Dgalasa.target.repo=file:target/isolated/maven \
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
@@ -394,7 +394,7 @@ jobs:
       - name: Build MVP Javadoc with maven
         working-directory: ./isolated/mvp
         run: |
-          mvn -f ${{github.workspace}}/isolated/mvp/pomJavaDoc.xml process-sources \
+          mvn -f ${{ github.workspace }}/isolated/mvp/pomJavaDoc.xml process-sources -X \
           -Dgpg.skip=true \
           -Dgalasa.target.repo=file:target/isolated/maven \
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
@@ -411,7 +411,7 @@ jobs:
           GITHUB_TOKEN_READ_PACKAGES_USERNAME: ${{ secrets.READ_GITHUB_PACKAGES_USERNAME }}
           GITHUB_TOKEN_READ_PACKAGES_PASSWORD: ${{ secrets.READ_GITHUB_PACKAGES_TOKEN }}
         run: |
-          mvn -f ${{github.workspace}}/isolated/mvp/pomDocs.xml process-sources \
+          mvn -f ${{ github.workspace }}/isolated/mvp/pomDocs.xml process-sources -X \
           -Dgpg.skip=true \
           -Dgalasa.target.repo=file:target/isolated/maven \
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
@@ -440,7 +440,7 @@ jobs:
       - name: Build galasactl directory with maven
         working-directory: ./isolated/mvp
         run: |
-          mvn -f ${{github.workspace}}/isolated/mvp/pomGalasactl.xml validate \
+          mvn -f ${{ github.workspace }}/isolated/mvp/pomGalasactl.xml validate -X \
           -Dgpg.skip=true \
           -Dgalasa.target.repo=file:target/isolated/maven \
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
@@ -460,7 +460,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: ${{github.workspace}}/isolated/dockerfiles/dockerfile.isolated
+          file: ${{ github.workspace }}/isolated/dockerfiles/dockerfile.isolated
           load: true
           tags: galasa-mvp:test
           build-args: |
@@ -470,7 +470,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: ${{github.workspace}}/isolated/dockerfiles/dockerfile.isolated
+          file: ${{ github.workspace }}/isolated/dockerfiles/dockerfile.isolated
           load: true
           tags: galasa-mvp-tar:test
           build-args: |
@@ -481,10 +481,10 @@ jobs:
       - name: Build MVP zip with maven
         working-directory: ./isolated/mvp
         run: |
-          mvn -f ${{github.workspace}}/isolated/mvp/pomZip.xml deploy \
+          mvn -f ${{ github.workspace }}/isolated/mvp/pomZip.xml deploy -X \
           -Dgpg.skip=true \
           -Dgalasa.target.repo=file:target/isolated/maven \
-          -Dgalasa.release.repo=file:${{github.workspace}}/isolated/mvp/repo \
+          -Dgalasa.release.repo=file:${{ github.workspace }}/isolated/mvp/repo \
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
@@ -497,7 +497,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: ./isolated/mvp
-          file: ${{github.workspace}}/isolated/dockerfiles/dockerfile.isolatedzip
+          file: ${{ github.workspace }}/isolated/dockerfiles/dockerfile.isolatedzip
           load: true
           tags: galasa-mvp-zip:test
           build-args: |

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -55,6 +55,11 @@ jobs:
         run: |
           docker run --rm -v ${{ github.workspace }}:/var/root/ ghcr.io/galasa-dev/galasabld-amd64:main template --releaseMetadata var/root/framework/release.yaml --releaseMetadata /var/root/extensions/release.yaml --releaseMetadata /var/root/managers/release.yaml --releaseMetadata /var/root/obr/release.yaml --template /var/root/isolated/full/pom.template --output /var/root/isolated/full/pom.xml --isolated
       
+      - name: Make directory to place build logs in
+        working-directory: ./isolated/full
+        run: |
+          mkdir isolated-build-logs
+
       - name: Build Isolated pom.xml with maven
         working-directory: ./isolated/full
         env:
@@ -320,6 +325,11 @@ jobs:
         run: |
           docker run --rm -v ${{ github.workspace }}:/var/root/ ghcr.io/galasa-dev/galasabld-amd64:main template --releaseMetadata var/root/framework/release.yaml --releaseMetadata /var/root/extensions/release.yaml --releaseMetadata /var/root/managers/release.yaml --releaseMetadata /var/root/obr/release.yaml --template /var/root/isolated/mvp/pom.template --output /var/root/isolated/mvp/pom.xml --mvp
       
+      - name: Make directory to place build logs in
+        working-directory: ./isolated/mvp
+        run: |
+          mkdir mvp-build-logs
+
       - name: Build MVP pom.xml with maven
         working-directory: ./isolated/mvp
         env:


### PR DESCRIPTION
## Why?

- Story https://github.com/galasa-dev/projectmanagement/issues/1967
   - Upgrade Java version to 17
   - Upload Maven log as artefact to workflow
   - Add more logging with `-X`

- Story https://github.com/galasa-dev/projectmanagement/issues/1958
   - Parameterise the Isolated workflow to run on other branches other than main for releases/branch builds 

Combining these changes into one PR to avoid lots of build triggering.