### PR TITLE
Fix isolated.tar build step

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -268,9 +268,8 @@ jobs:
           tags: ${{ steps.metadata-galasa-isolated-tar.outputs.tags }}
           labels: ${{ steps.metadata-galasa-isolated-tar.outputs.labels }}
           build-args: |
-            --tarPath
-            isolated/full/target/isolated/isolated.tar
             directory=isolated/full
+          outputs: type=tar,dest=isolated/full/target/isolated/isolated.tar
 
       - name: Build Isolated zip with maven
         working-directory: ./isolated/full
@@ -571,9 +570,8 @@ jobs:
           tags: ${{ steps.metadata-galasa-mvp-tar.outputs.tags }}
           labels: ${{ steps.metadata-galasa-mvp-tar.outputs.labels }}
           build-args: |
-            --tarPath
-            isolated/mvp/target/isolated/isolated.tar
             directory=isolated/mvp
+          outputs: type=tar,dest=isolated/mvp/target/isolated/isolated.tar
 
       - name: Build MVP zip with maven
         working-directory: ./isolated/mvp

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -245,9 +245,8 @@ jobs:
           load: true
           tags: galasa-isolated-tar:test
           build-args: |
-            --tarPath
-            isolated/full/target/isolated/isolated.tar
             directory=isolated/full
+          outputs: type=tar,dest=isolated/full/target/isolated/isolated.tar
 
       - name: Build Isolated zip with maven
         working-directory: ./isolated/full
@@ -514,9 +513,8 @@ jobs:
           load: true
           tags: galasa-mvp-tar:test
           build-args: |
-            --tarPath
-            isolated/mvp/target/isolated/isolated.tar
             directory=isolated/mvp
+          outputs: type=tar,dest=isolated/mvp/target/isolated/isolated.tar
 
       - name: Build MVP zip with maven
         working-directory: ./isolated/mvp


### PR DESCRIPTION
The step currently was not building the isolated.tar file which is part of the Isolated and MVP zips. The docker/build-push-action requires the instruction to create a tar ball passed in as an `outputs` value instead of as a `--tarPath` flag like Kaniko did in the Tekton builds.