### PR TITLE
Bump simplatform to 0.38.0

### DIFF
--- a/full/pom.template
+++ b/full/pom.template
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>dev.galasa</groupId>
             <artifactId>galasa-simplatform</artifactId>
-            <version>0.24.0</version>
+            <version>0.38.0</version>
             <type>jar</type>
         </dependency>
 

--- a/full/resources/run-simplatform.sh
+++ b/full/resources/run-simplatform.sh
@@ -122,7 +122,7 @@ fi
 # Main logic.
 #-----------------------------------------------------------------------------------------  
 
-SIMBANK_VERSION="0.24.0"
+SIMBANK_VERSION="0.38.0"
 
 function run_server {
     h1 "Running Simbank back-end server application (version ${SIMBANK_VERSION}) ..."

--- a/mvp/pom.template
+++ b/mvp/pom.template
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>dev.galasa</groupId>
             <artifactId>galasa-simplatform</artifactId>
-            <version>0.24.0</version>
+            <version>0.38.0</version>
             <type>jar</type>
         </dependency>
 

--- a/mvp/resources/run-simplatform.sh
+++ b/mvp/resources/run-simplatform.sh
@@ -122,7 +122,7 @@ fi
 # Main logic.
 #-----------------------------------------------------------------------------------------  
 
-SIMBANK_VERSION="0.24.0"
+SIMBANK_VERSION="0.38.0"
 
 function run_server {
     h1 "Running Simbank back-end server application (version ${SIMBANK_VERSION}) ..."


### PR DESCRIPTION
## Why?
Fixes isolated build failures now that simplatform has been bumped to 0.38.0 in https://github.com/galasa-dev/simplatform/pull/169