### PR TITLE
Use httpd:alpine image in isolated dockerfile

### DIFF
--- a/dockerfiles/dockerfile.isolated
+++ b/dockerfiles/dockerfile.isolated
@@ -1,4 +1,4 @@
-FROM harbor.galasa.dev/docker_proxy_cache/library/httpd:2.4.59
+FROM harbor.galasa.dev/docker_proxy_cache/library/httpd:alpine
 
 ARG directory
 


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/2057

httpd:2.4.59 contains several vulnerabilities, so switching over to use httpd:alpine instead.