### PR TITLE
Update pom.template for Isolated and MVP

### DIFF
--- a/full/pom.template
+++ b/full/pom.template
@@ -14,6 +14,18 @@
 		<galasa.target.repo>file:${project.build.directory}/repo</galasa.target.repo>
 	</properties>
 
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>dev.galasa</groupId>
+				<artifactId>dev.galasa.platform</artifactId>
+				<version>0.38.0</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<dependencies>
 		<dependency>
 			<groupId>dev.galasa</groupId>
@@ -39,8 +51,8 @@
 {{range .Artifacts}}
         <dependency>
             <groupId>{{.GroupId}}</groupId>
-            <artifactId>{{.ArtifactId}}</artifactId>
-            <version>{{.Version}}</version>
+            <artifactId>{{.ArtifactId}}</artifactId>{{if .Version}}
+            <version>{{.Version}}</version>{{end}}
         </dependency>
     {{end}}
 
@@ -104,7 +116,6 @@
 		<dependency>
 			<groupId>org.osgi</groupId>
 			<artifactId>org.osgi.service.component.annotations</artifactId>
-			<version>1.3.0</version>
 			<type>jar</type>
 		</dependency>
 
@@ -112,43 +123,36 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-api</artifactId>
-			<version>3.141.59</version>
 			<type>jar</type>
 		</dependency>
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-ie-driver</artifactId>
-			<version>3.141.59</version>
 			<type>jar</type>
 		</dependency>
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-edge-driver</artifactId>
-			<version>3.141.59</version>
 			<type>jar</type>
 		</dependency>
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-chrome-driver</artifactId>
-			<version>3.141.59</version>
 			<type>jar</type>
 		</dependency>
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-firefox-driver</artifactId>
-			<version>3.141.59</version>
 			<type>jar</type>
 		</dependency>
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-opera-driver</artifactId>
-			<version>3.141.59</version>
 			<type>jar</type>
 		</dependency>
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-remote-driver</artifactId>
-			<version>3.141.59</version>
 			<type>jar</type>
 		</dependency>
 

--- a/full/pom.template
+++ b/full/pom.template
@@ -41,6 +41,13 @@
             <type>pom</type>
         </dependency>
 
+		<dependency>
+            <groupId>dev.galasa</groupId>
+            <artifactId>dev.galasa.platform</artifactId>
+            <version>{{.Release}}</version>
+            <type>pom</type>
+        </dependency>
+
         <dependency>
             <groupId>dev.galasa</groupId>
             <artifactId>galasa-simplatform</artifactId>

--- a/mvp/pom.template
+++ b/mvp/pom.template
@@ -14,6 +14,18 @@
 		<galasa.target.repo>file:${project.build.directory}/repo</galasa.target.repo>
 	</properties>
 
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>dev.galasa</groupId>
+				<artifactId>dev.galasa.platform</artifactId>
+				<version>0.38.0</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<dependencies>
         <dependency>
             <groupId>dev.galasa</groupId>
@@ -39,8 +51,8 @@
 {{range .Artifacts}}
         <dependency>
             <groupId>{{.GroupId}}</groupId>
-            <artifactId>{{.ArtifactId}}</artifactId>
-            <version>{{.Version}}</version>
+            <artifactId>{{.ArtifactId}}</artifactId>{{if .Version}}
+            <version>{{.Version}}</version>{{end}}
         </dependency>
     {{end}}
     
@@ -90,7 +102,6 @@
 		<dependency>
 			<groupId>org.osgi</groupId>
 			<artifactId>org.osgi.service.component.annotations</artifactId>
-			<version>1.3.0</version>
 			<type>jar</type>
 		</dependency>
 
@@ -98,43 +109,36 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-api</artifactId>
-			<version>3.141.59</version>
 			<type>jar</type>
 		</dependency>
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-ie-driver</artifactId>
-			<version>3.141.59</version>
 			<type>jar</type>
 		</dependency>
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-edge-driver</artifactId>
-			<version>3.141.59</version>
 			<type>jar</type>
 		</dependency>
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-chrome-driver</artifactId>
-			<version>3.141.59</version>
 			<type>jar</type>
 		</dependency>
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-firefox-driver</artifactId>
-			<version>3.141.59</version>
 			<type>jar</type>
 		</dependency>
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-opera-driver</artifactId>
-			<version>3.141.59</version>
 			<type>jar</type>
 		</dependency>
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-remote-driver</artifactId>
-			<version>3.141.59</version>
 			<type>jar</type>
 		</dependency>
 	</dependencies>

--- a/mvp/pom.template
+++ b/mvp/pom.template
@@ -41,6 +41,13 @@
             <type>pom</type>
         </dependency>
 
+		<dependency>
+            <groupId>dev.galasa</groupId>
+            <artifactId>dev.galasa.platform</artifactId>
+            <version>{{.Release}}</version>
+            <type>pom</type>
+        </dependency>
+
         <dependency>
             <groupId>dev.galasa</groupId>
             <artifactId>galasa-simplatform</artifactId>


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2052

Since removing versions of some artifacts from the OBR's release.yaml ([PR here](https://github.com/galasa-dev/galasa/pull/70/files#diff-76c75358ba18f9743d0614b1166882360699caac47e3fd05688ec098a5613ebd) - the Isolated and MVP's pom.xml requires that dev.galasa.platform be used as `dependencyManagement` to provide the versions where not explicitly included.
dev.galasa.platform has also been included as a POM artifact so that it is shipped in both zips for users of the Isolated/MVP to access it. 