### PR TITLE
Bump commons-parent to 72 and org.apache to 33

### DIFF
--- a/full/pom.template
+++ b/full/pom.template
@@ -94,17 +94,19 @@
 
 
 
-
+        <!--
+            To resolve commons-logging:1.3.4, commons-parent:72 and org.apache:33 are required.
+        -->
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-parent</artifactId>
-			<version>34</version>
+			<version>72</version>
 			<type>pom</type>
 		</dependency>
 		<dependency>
 			<groupId>org.apache</groupId>
 			<artifactId>apache</artifactId>
-			<version>13</version>
+			<version>33</version>
 			<type>pom</type>
 		</dependency>
 

--- a/full/pom.template
+++ b/full/pom.template
@@ -119,7 +119,7 @@
 		<dependency>
 			<groupId>org.junit</groupId>
 			<artifactId>junit-bom</artifactId>
-			<version>5.2.0</version>
+			<version>5.11.0-M2</version>
 			<type>pom</type>
 		</dependency>
 		<dependency>

--- a/mvp/pom.template
+++ b/mvp/pom.template
@@ -106,7 +106,7 @@
 		<dependency>
 			<groupId>org.junit</groupId>
 			<artifactId>junit-bom</artifactId>
-			<version>5.2.0</version>
+			<version>5.11.0-M2</version>
 			<type>pom</type>
 		</dependency>
 		<dependency>

--- a/mvp/pom.template
+++ b/mvp/pom.template
@@ -82,16 +82,19 @@
             <type>obr</type>
         </dependency>
 
+        <!--
+            To resolve commons-logging:1.3.4, commons-parent:72 and org.apache:33 are required.
+        -->
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-parent</artifactId>
-			<version>34</version>
+			<version>72</version>
 			<type>pom</type>
 		</dependency>
 		<dependency>
 			<groupId>org.apache</groupId>
 			<artifactId>apache</artifactId>
-			<version>13</version>
+			<version>33</version>
 			<type>pom</type>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
## Why?
commons-logging was recently bumped up to 1.3.4 and a couple of isolated regression tests have failed because commons-parent:72 couldn't be resolved. This is because commons-logging:1.3.4 references commons-parent:72 in its [pom](https://repo1.maven.org/maven2/commons-logging/commons-logging/1.3.4/commons-logging-1.3.4.pom). Bumping commons-parent also involves bumping org.apache to 33 as defined in the [pom](https://repo1.maven.org/maven2/org/apache/commons/commons-parent/34/commons-parent-34.pom) for commons-parent:72.

This PR bumps commons-parent from 34 to 72 and org.apache from 13 to 33 so that commons-logging:1.3.4 can (hopefully) be resolved.