### PR TITLE
Add dev.galasa.wrapping.parent pom to isolated and mvp packaging

### DIFF
--- a/full/pom.template
+++ b/full/pom.template
@@ -41,6 +41,13 @@
             <type>pom</type>
         </dependency>
 
+        <dependency>
+            <groupId>dev.galasa</groupId>
+            <artifactId>dev.galasa.wrapping.parent</artifactId>
+            <version>{{.Release}}</version>
+            <type>pom</type>
+        </dependency>
+
 		<dependency>
             <groupId>dev.galasa</groupId>
             <artifactId>dev.galasa.platform</artifactId>

--- a/mvp/pom.template
+++ b/mvp/pom.template
@@ -41,6 +41,13 @@
             <type>pom</type>
         </dependency>
 
+        <dependency>
+            <groupId>dev.galasa</groupId>
+            <artifactId>dev.galasa.wrapping.parent</artifactId>
+            <version>{{.Release}}</version>
+            <type>pom</type>
+        </dependency>
+
 		<dependency>
             <groupId>dev.galasa</groupId>
             <artifactId>dev.galasa.platform</artifactId>


### PR DESCRIPTION
## Why?
The compilation regression tests (e.g. CompilationLocalOfflineJava11UbuntuMVP, CompilationLocalOfflineJava11UbuntuIsolated, CompilationLocalJava11UbuntuIsolated, etc.) are failing to resolve dev.galasa.wrapping.parent:

```
* What went wrong:
Execution failed for task ':compileJava'.
> Could not resolve all files for configuration ':compileClasspath'.
   > Could not resolve dev.galasa:dev.galasa.wrapping.httpclient-osgi:0.38.0.
     Required by:
         project : > dev.galasa:dev.galasa.http.manager:0.38.0
      > Could not resolve dev.galasa:dev.galasa.wrapping.httpclient-osgi:0.38.0.
         > Could not parse POM /home/galasa48/galasaconfig/isolatedrepo/maven/dev/galasa/dev.galasa.wrapping.httpclient-osgi/0.38.0/dev.galasa.wrapping.httpclient-osgi-0.38.0.pom
            > Could not find dev.galasa:dev.galasa.wrapping.parent:0.38.0.
              Searched in the following locations:
                - file:/home/galasa48/galasaconfig/isolatedrepo/maven/dev/galasa/dev.galasa.wrapping.parent/0.38.0/dev.galasa.wrapping.parent-0.38.0.pom
              If the artifact you are trying to retrieve can be found in the repository but without metadata in 'Maven POM' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
   > Could not resolve dev.galasa:dev.galasa.wrapping.httpclient-osgi:0.38.0.
     Required by:
         project : > dev.galasa:dev.galasa.artifact.manager:0.38.0 > dev.galasa:dev.galasa.platform:0.38.0
      > Could not resolve dev.galasa:dev.galasa.wrapping.httpclient-osgi:0.38.0.
         > Could not parse POM /home/galasa48/galasaconfig/isolatedrepo/maven/dev/galasa/dev.galasa.wrapping.httpclient-osgi/0.38.0/dev.galasa.wrapping.httpclient-osgi-0.38.0.pom
            > Could not find dev.galasa:dev.galasa.wrapping.parent:0.38.0.
              Searched in the following locations:
                - file:/home/galasa48/galasaconfig/isolatedrepo/maven/dev/galasa/dev.galasa.wrapping.parent/0.38.0/dev.galasa.wrapping.parent-0.38.0.pom
              If the artifact you are trying to retrieve can be found in the repository but without metadata in 'Maven POM' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
```

This PR adds the missing pom into the isolated and mvp packaging.