### PR TITLE
Bump pom versions to resolve httpclient-osgi and commons-codec

### DIFF
--- a/full/pom2.xml
+++ b/full/pom2.xml
@@ -7,7 +7,7 @@
 
 	<groupId>dev.galasa</groupId>
 	<artifactId>galasa-isolated-full-maven-repo2</artifactId>
-	<version>0.16.0</version>
+	<version>0.38.0</version>
 	<packaging>pom</packaging>
 
 	<properties>

--- a/full/pom3.xml
+++ b/full/pom3.xml
@@ -7,7 +7,7 @@
 
 	<groupId>dev.galasa</groupId>
 	<artifactId>galasa-isolated-full-maven-repo3</artifactId>
-	<version>0.16.0</version>
+	<version>0.38.0</version>
 	<packaging>pom</packaging>
 
 	<properties>
@@ -15,47 +15,19 @@
 	</properties>
 
 	<dependencies>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.13</version>
-            <type>jar</type>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpcore</artifactId>
-            <version>4.4.14</version>
-            <type>jar</type>
-        </dependency>
+        <!--
+            The following POMs are used to resolve dev.galasa.wrapping.httpclient-osgi
+        -->
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcomponents-core</artifactId>
-            <version>4.4.14</version>
+            <version>4.4.16</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpmime</artifactId>
-            <version>4.5.13</version>
-            <type>jar</type>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient-cache</artifactId>
-            <version>4.5.13</version>
-            <type>jar</type>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>fluent-hc</artifactId>
-            <version>4.5.13</version>
-            <type>jar</type>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcomponents-client</artifactId>
-            <version>4.5.13</version>
+            <version>4.5.14</version>
             <type>pom</type>
         </dependency>
         <dependency>

--- a/full/pom4.xml
+++ b/full/pom4.xml
@@ -7,7 +7,7 @@
 
 	<groupId>dev.galasa</groupId>
 	<artifactId>galasa-isolated-full-maven-repo4</artifactId>
-	<version>0.16.0</version>
+	<version>0.38.0</version>
 	<packaging>pom</packaging>
 
 	<properties>

--- a/full/pom5.xml
+++ b/full/pom5.xml
@@ -7,7 +7,7 @@
 
 	<groupId>dev.galasa</groupId>
 	<artifactId>galasa-isolated-full-maven-repo5</artifactId>
-	<version>0.16.0</version>
+	<version>0.38.0</version>
 	<packaging>pom</packaging>
 
 	<properties>
@@ -45,19 +45,28 @@
 			<artifactId>biz.aQute.bnd.builder.gradle.plugin</artifactId>
 			<version>5.3.0</version>
 		</dependency>
+
+        <!--
+            The following POMs are used to resolve commons-codec:1.16.1
+        -->
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-parent</artifactId>
-			<version>52</version>
+			<version>66</version>
 			<type>pom</type>
 		</dependency>
 		<dependency>
 			<groupId>org.apache</groupId>
 			<artifactId>apache</artifactId>
-			<version>23</version>
+			<version>31</version>
 			<type>pom</type>
 		</dependency>
-
+		<dependency>
+			<groupId>org.junit</groupId>
+			<artifactId>junit-bom</artifactId>
+			<version>5.10.1</version>
+			<type>pom</type>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/full/pom6.xml
+++ b/full/pom6.xml
@@ -7,7 +7,7 @@
 
 	<groupId>dev.galasa</groupId>
 	<artifactId>galasa-isolated-full-maven-repo6</artifactId>
-	<version>0.16.0</version>
+	<version>0.38.0</version>
 	<packaging>pom</packaging>
 
 	<properties>

--- a/mvp/pom2.xml
+++ b/mvp/pom2.xml
@@ -7,7 +7,7 @@
 
 	<groupId>dev.galasa</groupId>
 	<artifactId>galasa-isolated-mvp-maven-repo2</artifactId>
-	<version>0.16.0</version>
+	<version>0.38.0</version>
 	<packaging>pom</packaging>
 
 	<properties>

--- a/mvp/pom3.xml
+++ b/mvp/pom3.xml
@@ -7,7 +7,7 @@
 
 	<groupId>dev.galasa</groupId>
 	<artifactId>galasa-isolated-mvp-maven-repo3</artifactId>
-	<version>0.16.0</version>
+	<version>0.38.0</version>
 	<packaging>pom</packaging>
 
 	<properties>
@@ -15,46 +15,19 @@
 	</properties>
 
 	<dependencies>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.13</version>
-            <type>jar</type>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpcore</artifactId>
-            <version>4.4.14</version>
-            <type>jar</type>
-        </dependency>
+        <!--
+            The following POMs are used to resolve dev.galasa.wrapping.httpclient-osgi
+        -->
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcomponents-core</artifactId>
-            <version>4.4.14</version>
+            <version>4.4.16</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpmime</artifactId>
-            <version>4.5.13</version>
-            <type>jar</type>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient-cache</artifactId>
-            <version>4.5.13</version>
-            <type>jar</type>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>fluent-hc</artifactId>
-            <version>4.5.13</version>
-            <type>jar</type>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcomponents-client</artifactId>
-            <version>4.5.13</version>
+            <version>4.5.14</version>
             <type>pom</type>
         </dependency>
         <dependency>

--- a/mvp/pom4.xml
+++ b/mvp/pom4.xml
@@ -7,7 +7,7 @@
 
 	<groupId>dev.galasa</groupId>
 	<artifactId>galasa-isolated-mvp-maven-repo4</artifactId>
-	<version>0.16.0</version>
+	<version>0.38.0</version>
 	<packaging>pom</packaging>
 
 	<properties>

--- a/mvp/pom5.xml
+++ b/mvp/pom5.xml
@@ -7,7 +7,7 @@
 
 	<groupId>dev.galasa</groupId>
 	<artifactId>galasa-isolated-mvp-maven-repo5</artifactId>
-	<version>0.16.0</version>
+	<version>0.38.0</version>
 	<packaging>pom</packaging>
 
 	<properties>
@@ -45,18 +45,28 @@
 			<artifactId>biz.aQute.bnd.builder.gradle.plugin</artifactId>
 			<version>5.3.0</version>
 		</dependency>
+
+        <!--
+            The following POMs are used to resolve commons-codec:1.16.1
+        -->
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-parent</artifactId>
-            <version>52</version>
+            <version>66</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>org.apache</groupId>
             <artifactId>apache</artifactId>
-            <version>23</version>
+            <version>31</version>
             <type>pom</type>
         </dependency>
+		<dependency>
+			<groupId>org.junit</groupId>
+			<artifactId>junit-bom</artifactId>
+			<version>5.10.1</version>
+			<type>pom</type>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/mvp/pom6.xml
+++ b/mvp/pom6.xml
@@ -7,7 +7,7 @@
 
 	<groupId>dev.galasa</groupId>
 	<artifactId>galasa-isolated-mvp-maven-repo5</artifactId>
-	<version>0.16.0</version>
+	<version>0.38.0</version>
 	<packaging>pom</packaging>
 
 	<properties>


### PR DESCRIPTION
## Why?
Changes in https://github.com/galasa-dev/isolated/pull/80 revealed more errors when resolving httpcomponents and commons-codec dependencies as shown below because these versions were recently changed in the core galasa codebase.

```
* What went wrong:
Execution failed for task ':compileJava'.
> Could not resolve all files for configuration ':compileClasspath'.
   > Could not resolve commons-codec:commons-codec:1.16.1.
     Required by:
         project :
      > Could not resolve commons-codec:commons-codec:1.16.1.
         > Could not parse POM /home/galasa38/galasaconfig/isolatedrepo/maven/commons-codec/commons-codec/1.16.1/commons-codec-1.16.1.pom
            > Could not find org.apache.commons:commons-parent:66.
              Searched in the following locations:
                - file:/home/galasa38/galasaconfig/isolatedrepo/maven/org/apache/commons/commons-parent/66/commons-parent-66.pom
              If the artifact you are trying to retrieve can be found in the repository but without metadata in 'Maven POM' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
   > Could not find org.apache.httpcomponents:httpcore:4.4.16.
     Searched in the following locations:
       - file:/home/galasa38/galasaconfig/isolatedrepo/maven/org/apache/httpcomponents/httpcore/4.4.16/httpcore-4.4.16.pom
     If the artifact you are trying to retrieve can be found in the repository but without metadata in 'Maven POM' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
     Required by:
         project :
   > Could not find org.apache.httpcomponents:httpclient:4.5.14.
     Searched in the following locations:
       - file:/home/galasa38/galasaconfig/isolatedrepo/maven/org/apache/httpcomponents/httpclient/4.5.14/httpclient-4.5.14.pom
     If the artifact you are trying to retrieve can be found in the repository but without metadata in 'Maven POM' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
     Required by:
         project : > dev.galasa:dev.galasa.core.manager:0.38.0 > dev.galasa:dev.galasa.platform:0.38.0
         project : > dev.galasa:dev.galasa.http.manager:0.38.0 > dev.galasa:dev.galasa.wrapping.httpclient-osgi:0.38.0
   > Could not resolve commons-codec:commons-codec:1.16.1.
     Required by:
         project : > dev.galasa:dev.galasa.core.manager:0.38.0 > dev.galasa:dev.galasa.platform:0.38.0
         project : > dev.galasa:dev.galasa.http.manager:0.38.0 > dev.galasa:dev.galasa.wrapping.httpclient-osgi:0.38.0
      > Could not resolve commons-codec:commons-codec:1.16.1.
         > Could not parse POM /home/galasa38/galasaconfig/isolatedrepo/maven/commons-codec/commons-codec/1.16.1/commons-codec-1.16.1.pom
            > Could not find org.apache.commons:commons-parent:66.
              Searched in the following locations:
                - file:/home/galasa38/galasaconfig/isolatedrepo/maven/org/apache/commons/commons-parent/66/commons-parent-66.pom
              If the artifact you are trying to retrieve can be found in the repository but without metadata in 'Maven POM' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
   > Could not find org.apache.httpcomponents:httpcore:4.4.16.
     Searched in the following locations:
       - file:/home/galasa38/galasaconfig/isolatedrepo/maven/org/apache/httpcomponents/httpcore/4.4.16/httpcore-4.4.16.pom
     If the artifact you are trying to retrieve can be found in the repository but without metadata in 'Maven POM' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
     Required by:
         project : > dev.galasa:dev.galasa.core.manager:0.38.0 > dev.galasa:dev.galasa.platform:0.38.0
         project : > dev.galasa:dev.galasa.http.manager:0.38.0 > dev.galasa:dev.galasa.wrapping.httpclient-osgi:0.38.0
   > Could not find org.apache.httpcomponents:httpmime:4.5.14.
     Searched in the following locations:
       - file:/home/galasa38/galasaconfig/isolatedrepo/maven/org/apache/httpcomponents/httpmime/4.5.14/httpmime-4.5.14.pom
     If the artifact you are trying to retrieve can be found in the repository but without metadata in 'Maven POM' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
     Required by:
         project : > dev.galasa:dev.galasa.core.manager:0.38.0 > dev.galasa:dev.galasa.platform:0.38.0
         project : > dev.galasa:dev.galasa.http.manager:0.38.0 > dev.galasa:dev.galasa.wrapping.httpclient-osgi:0.38.0
```


This PR fixes these resolution errors and moves the httpcomponents jars out of the isolated and mvp poms so that they can be embedded along with the other dependency jars in the pom.template files.

The org.apache.httpcomponents.httpclient-osgi bundle was replaced with dev.galasa.wrapping.httpclient-osgi bundle and that doesn't use httpclient-cache or fluent-hc, so these have been removed from the isolated and mvp packaging.