### PR TITLE
Add junit-bom:5.2.0 back in to fix errors when resolving assertj-core:3.11.1

### DIFF
--- a/full/pom.template
+++ b/full/pom.template
@@ -116,7 +116,16 @@
 			<version>33</version>
 			<type>pom</type>
 		</dependency>
+		<dependency>
+			<groupId>org.junit</groupId>
+			<artifactId>junit-bom</artifactId>
+			<version>5.11.0-M2</version>
+			<type>pom</type>
+		</dependency>
 
+        <!--
+            The following POMs are used to resolve assertj-core:3.11.1
+        -->
 		<dependency>
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-parent-pom</artifactId>
@@ -126,9 +135,10 @@
 		<dependency>
 			<groupId>org.junit</groupId>
 			<artifactId>junit-bom</artifactId>
-			<version>5.11.0-M2</version>
+			<version>5.2.0</version>
 			<type>pom</type>
 		</dependency>
+
 		<dependency>
 			<groupId>org.osgi</groupId>
 			<artifactId>org.osgi.service.component.annotations</artifactId>

--- a/full/pom.template
+++ b/full/pom.template
@@ -123,22 +123,6 @@
 			<type>pom</type>
 		</dependency>
 
-        <!--
-            The following POMs are used to resolve assertj-core:3.11.1
-        -->
-		<dependency>
-			<groupId>org.assertj</groupId>
-			<artifactId>assertj-parent-pom</artifactId>
-			<version>2.2.1</version>
-			<type>pom</type>
-		</dependency>
-		<dependency>
-			<groupId>org.junit</groupId>
-			<artifactId>junit-bom</artifactId>
-			<version>5.2.0</version>
-			<type>pom</type>
-		</dependency>
-
 		<dependency>
 			<groupId>org.osgi</groupId>
 			<artifactId>org.osgi.service.component.annotations</artifactId>

--- a/full/pom2.xml
+++ b/full/pom2.xml
@@ -33,6 +33,22 @@
 			<version>10</version>
 			<type>pom</type>
 		</dependency>
+
+        <!--
+            The following POMs are used to resolve assertj-core:3.11.1
+        -->
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-parent-pom</artifactId>
+			<version>2.2.1</version>
+			<type>pom</type>
+		</dependency>
+		<dependency>
+			<groupId>org.junit</groupId>
+			<artifactId>junit-bom</artifactId>
+			<version>5.2.0</version>
+			<type>pom</type>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/mvp/pom.template
+++ b/mvp/pom.template
@@ -105,6 +105,16 @@
 			<type>pom</type>
 		</dependency>
 		<dependency>
+			<groupId>org.junit</groupId>
+			<artifactId>junit-bom</artifactId>
+			<version>5.11.0-M2</version>
+			<type>pom</type>
+		</dependency>
+
+        <!--
+            The following POMs are used to resolve assertj-core:3.11.1
+        -->
+		<dependency>
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-parent-pom</artifactId>
 			<version>2.2.1</version>
@@ -113,9 +123,10 @@
 		<dependency>
 			<groupId>org.junit</groupId>
 			<artifactId>junit-bom</artifactId>
-			<version>5.11.0-M2</version>
+			<version>5.2.0</version>
 			<type>pom</type>
 		</dependency>
+
 		<dependency>
 			<groupId>org.osgi</groupId>
 			<artifactId>org.osgi.service.component.annotations</artifactId>

--- a/mvp/pom.template
+++ b/mvp/pom.template
@@ -111,22 +111,6 @@
 			<type>pom</type>
 		</dependency>
 
-        <!--
-            The following POMs are used to resolve assertj-core:3.11.1
-        -->
-		<dependency>
-			<groupId>org.assertj</groupId>
-			<artifactId>assertj-parent-pom</artifactId>
-			<version>2.2.1</version>
-			<type>pom</type>
-		</dependency>
-		<dependency>
-			<groupId>org.junit</groupId>
-			<artifactId>junit-bom</artifactId>
-			<version>5.2.0</version>
-			<type>pom</type>
-		</dependency>
-
 		<dependency>
 			<groupId>org.osgi</groupId>
 			<artifactId>org.osgi.service.component.annotations</artifactId>

--- a/mvp/pom2.xml
+++ b/mvp/pom2.xml
@@ -33,6 +33,22 @@
 			<version>10</version>
 			<type>pom</type>
 		</dependency>
+
+        <!--
+            The following POMs are used to resolve assertj-core:3.11.1
+        -->
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-parent-pom</artifactId>
+			<version>2.2.1</version>
+			<type>pom</type>
+		</dependency>
+		<dependency>
+			<groupId>org.junit</groupId>
+			<artifactId>junit-bom</artifactId>
+			<version>5.2.0</version>
+			<type>pom</type>
+		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
## Why?
Changes in https://github.com/galasa-dev/isolated/pull/79 replaced `junit-bom:5.2.0` with `5.11.0-M2` since `commons-parent:72` uses this newer version. However, this has caused the `compilation.simbank.local.offlline` regression tests to fail as they require `junit-bom:5.2.0`.

To get these tests working again, this PR adds `junit-bom:5.2.0` back into the isolated and mvp packaging.