### PR TITLE
Bump simbank versions to 0.38.0

### DIFF
--- a/full/pom.template
+++ b/full/pom.template
@@ -80,19 +80,19 @@
         <dependency>
             <groupId>dev.galasa</groupId>
             <artifactId>dev.galasa.simbank.manager</artifactId>
-            <version>0.25.0</version>
+            <version>0.38.0</version>
             <type>jar</type>
         </dependency>
         <dependency>
             <groupId>dev.galasa</groupId>
             <artifactId>dev.galasa.simbank.tests</artifactId>
-            <version>0.25.0</version>
+            <version>0.38.0</version>
             <type>jar</type>
         </dependency>
         <dependency>
             <groupId>dev.galasa</groupId>
             <artifactId>dev.galasa.simbank.obr</artifactId>
-            <version>0.25.0</version>
+            <version>0.38.0</version>
             <type>obr</type>
         </dependency>
 

--- a/mvp/pom.template
+++ b/mvp/pom.template
@@ -73,19 +73,19 @@
         <dependency>
             <groupId>dev.galasa</groupId>
             <artifactId>dev.galasa.simbank.manager</artifactId>
-            <version>0.25.0</version>
+            <version>0.38.0</version>
             <type>jar</type>
         </dependency>
         <dependency>
             <groupId>dev.galasa</groupId>
             <artifactId>dev.galasa.simbank.tests</artifactId>
-            <version>0.25.0</version>
+            <version>0.38.0</version>
             <type>jar</type>
         </dependency>
         <dependency>
             <groupId>dev.galasa</groupId>
             <artifactId>dev.galasa.simbank.obr</artifactId>
-            <version>0.25.0</version>
+            <version>0.38.0</version>
             <type>obr</type>
         </dependency>
 


### PR DESCRIPTION
## Why?
Related to changes in https://github.com/galasa-dev/simplatform/pull/172

**Note: Builds for this PR will fail until https://github.com/galasa-dev/simplatform/pull/172 is delivered**

## Changes
- Bump the simbank tests, manager, and OBR packages to 0.38.0 in the isolated and mvp packaging