### PR TITLE
Iss2052 - Use platform versions in Isolated/MVP

### DIFF
--- a/full/pom.template
+++ b/full/pom.template
@@ -19,7 +19,7 @@
 			<dependency>
 				<groupId>dev.galasa</groupId>
 				<artifactId>dev.galasa.platform</artifactId>
-				<version>0.38.0</version>
+				<version>{{.Release}}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>dev.galasa</groupId>
             <artifactId>galasa-simplatform</artifactId>
-            <version>0.38.0</version>
+            <version>{{.Release}}</version>
             <type>jar</type>
         </dependency>
 
@@ -80,19 +80,19 @@
         <dependency>
             <groupId>dev.galasa</groupId>
             <artifactId>dev.galasa.simbank.manager</artifactId>
-            <version>0.38.0</version>
+            <version>{{.Release}}</version>
             <type>jar</type>
         </dependency>
         <dependency>
             <groupId>dev.galasa</groupId>
             <artifactId>dev.galasa.simbank.tests</artifactId>
-            <version>0.38.0</version>
+            <version>{{.Release}}</version>
             <type>jar</type>
         </dependency>
         <dependency>
             <groupId>dev.galasa</groupId>
             <artifactId>dev.galasa.simbank.obr</artifactId>
-            <version>0.38.0</version>
+            <version>{{.Release}}</version>
             <type>obr</type>
         </dependency>
 

--- a/full/pom2.xml
+++ b/full/pom2.xml
@@ -14,17 +14,27 @@
 		<galasa.target.repo>file:${project.build.directory}/repo</galasa.target.repo>
 	</properties>
 
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>dev.galasa</groupId>
+				<artifactId>dev.galasa.platform</artifactId>
+				<version>0.38.0</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<dependencies>
         <dependency>
             <groupId>org.apache.derby</groupId>
             <artifactId>derbyclient</artifactId>
-            <version>10.14.2.0</version>
             <type>jar</type>
         </dependency>
         <dependency>
             <groupId>org.apache.derby</groupId>
             <artifactId>derby-project</artifactId>
-            <version>10.14.2.0</version>
             <type>pom</type>
         </dependency>
 		<dependency>
@@ -40,7 +50,6 @@
 		<dependency>
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-parent-pom</artifactId>
-			<version>2.2.1</version>
 			<type>pom</type>
 		</dependency>
 		<dependency>

--- a/full/pom3.xml
+++ b/full/pom3.xml
@@ -14,6 +14,18 @@
 		<galasa.target.repo>file:${project.build.directory}/repo</galasa.target.repo>
 	</properties>
 
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>dev.galasa</groupId>
+				<artifactId>dev.galasa.platform</artifactId>
+				<version>0.38.0</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<dependencies>
         <!--
             The following POMs are used to resolve dev.galasa.wrapping.httpclient-osgi
@@ -21,19 +33,16 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcomponents-core</artifactId>
-            <version>4.4.16</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcomponents-client</artifactId>
-            <version>4.5.14</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcomponents-parent</artifactId>
-            <version>11</version>
             <type>pom</type>
         </dependency>
 		<dependency>

--- a/full/pom5.xml
+++ b/full/pom5.xml
@@ -14,36 +14,42 @@
 		<galasa.target.repo>file:${project.build.directory}/repo</galasa.target.repo>
 	</properties>
 
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>dev.galasa</groupId>
+				<artifactId>dev.galasa.platform</artifactId>
+				<version>0.38.0</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<dependencies>
 		<dependency>
 			<groupId>biz.aQute.bnd</groupId>
 			<artifactId>biz.aQute.bnd.gradle</artifactId>
-			<version>5.3.0</version>
 		</dependency>
 		<dependency>
 			<groupId>biz.aQute.bnd</groupId>
 			<artifactId>biz.aQute.bnd.embedded-repo</artifactId>
-			<version>5.3.0</version>
 		</dependency>
 		<dependency>
 			<groupId>biz.aQute.bnd</groupId>
 			<artifactId>biz.aQute.bndlib</artifactId>
-			<version>5.3.0</version>
 		</dependency>
 		<dependency>
 			<groupId>biz.aQute.bnd</groupId>
 			<artifactId>biz.aQute.repository</artifactId>
-			<version>5.3.0</version>
 		</dependency>
 		<dependency>
 			<groupId>biz.aQute.bnd</groupId>
 			<artifactId>biz.aQute.resolve</artifactId>
-			<version>5.3.0</version>
 		</dependency>
 		<dependency>
 			<groupId>biz.aQute.bnd.builder</groupId>
 			<artifactId>biz.aQute.bnd.builder.gradle.plugin</artifactId>
-			<version>5.3.0</version>
 		</dependency>
 
         <!--

--- a/mvp/pom.template
+++ b/mvp/pom.template
@@ -19,7 +19,7 @@
 			<dependency>
 				<groupId>dev.galasa</groupId>
 				<artifactId>dev.galasa.platform</artifactId>
-				<version>0.38.0</version>
+				<version>{{.Release}}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>dev.galasa</groupId>
             <artifactId>galasa-simplatform</artifactId>
-            <version>0.38.0</version>
+            <version>{{.Release}}</version>
             <type>jar</type>
         </dependency>
 
@@ -73,19 +73,19 @@
         <dependency>
             <groupId>dev.galasa</groupId>
             <artifactId>dev.galasa.simbank.manager</artifactId>
-            <version>0.38.0</version>
+            <version>{{.Release}}</version>
             <type>jar</type>
         </dependency>
         <dependency>
             <groupId>dev.galasa</groupId>
             <artifactId>dev.galasa.simbank.tests</artifactId>
-            <version>0.38.0</version>
+            <version>{{.Release}}</version>
             <type>jar</type>
         </dependency>
         <dependency>
             <groupId>dev.galasa</groupId>
             <artifactId>dev.galasa.simbank.obr</artifactId>
-            <version>0.38.0</version>
+            <version>{{.Release}}</version>
             <type>obr</type>
         </dependency>
 

--- a/mvp/pom2.xml
+++ b/mvp/pom2.xml
@@ -14,17 +14,27 @@
 		<galasa.target.repo>file:${project.build.directory}/repo</galasa.target.repo>
 	</properties>
 
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>dev.galasa</groupId>
+				<artifactId>dev.galasa.platform</artifactId>
+				<version>0.38.0</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<dependencies>
         <dependency>
             <groupId>org.apache.derby</groupId>
             <artifactId>derbyclient</artifactId>
-            <version>10.14.2.0</version>
             <type>jar</type>
         </dependency>
         <dependency>
             <groupId>org.apache.derby</groupId>
             <artifactId>derby-project</artifactId>
-            <version>10.14.2.0</version>
             <type>pom</type>
         </dependency>
 		<dependency>
@@ -40,7 +50,6 @@
 		<dependency>
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-parent-pom</artifactId>
-			<version>2.2.1</version>
 			<type>pom</type>
 		</dependency>
 		<dependency>

--- a/mvp/pom3.xml
+++ b/mvp/pom3.xml
@@ -14,6 +14,18 @@
 		<galasa.target.repo>file:${project.build.directory}/repo</galasa.target.repo>
 	</properties>
 
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>dev.galasa</groupId>
+				<artifactId>dev.galasa.platform</artifactId>
+				<version>0.38.0</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<dependencies>
         <!--
             The following POMs are used to resolve dev.galasa.wrapping.httpclient-osgi
@@ -21,19 +33,16 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcomponents-core</artifactId>
-            <version>4.4.16</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcomponents-client</artifactId>
-            <version>4.5.14</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcomponents-parent</artifactId>
-            <version>11</version>
             <type>pom</type>
         </dependency>
 		<dependency>

--- a/mvp/pom5.xml
+++ b/mvp/pom5.xml
@@ -14,36 +14,42 @@
 		<galasa.target.repo>file:${project.build.directory}/repo</galasa.target.repo>
 	</properties>
 
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>dev.galasa</groupId>
+				<artifactId>dev.galasa.platform</artifactId>
+				<version>0.38.0</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<dependencies>
         <dependency>
 			<groupId>biz.aQute.bnd</groupId>
 			<artifactId>biz.aQute.bnd.gradle</artifactId>
-			<version>5.3.0</version>
 		</dependency>
 		<dependency>
 			<groupId>biz.aQute.bnd</groupId>
 			<artifactId>biz.aQute.bnd.embedded-repo</artifactId>
-			<version>5.3.0</version>
 		</dependency>
 		<dependency>
 			<groupId>biz.aQute.bnd</groupId>
 			<artifactId>biz.aQute.bndlib</artifactId>
-			<version>5.3.0</version>
 		</dependency>
 		<dependency>
 			<groupId>biz.aQute.bnd</groupId>
 			<artifactId>biz.aQute.repository</artifactId>
-			<version>5.3.0</version>
 		</dependency>
 		<dependency>
 			<groupId>biz.aQute.bnd</groupId>
 			<artifactId>biz.aQute.resolve</artifactId>
-			<version>5.3.0</version>
 		</dependency>
 		<dependency>
 			<groupId>biz.aQute.bnd.builder</groupId>
 			<artifactId>biz.aQute.bnd.builder.gradle.plugin</artifactId>
-			<version>5.3.0</version>
 		</dependency>
 
         <!--


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2052

- Remove hard coded versions for dependencies that are in the platform - version will be provided from there (completed in https://github.com/galasa-dev/galasa/pull/97)
- Now that all Galasa bundles are being upgraded each release, replace 0.38.0 version with `{{ .Release }}` in the pom.template so the version can be provided from the `galasabld` command and there's less version bumps to do per release