### PR TITLE
Build isolated.tar files manually

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -234,24 +234,10 @@ jobs:
           build-args: |
             directory=isolated/full
 
-      - name: Extract metadata for galasa-isolated-tar image
-        id: metadata-galasa-isolated-tar
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/galasa-isolated-tar
-
-      - name: Build Docker image for Isolated tar file
-        id: build-galasa-isolated-tar
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ${{ github.workspace }}/isolated/dockerfiles/dockerfile.isolated
-          push: true
-          tags: ${{ steps.metadata-galasa-isolated-tar.outputs.tags }}
-          labels: ${{ steps.metadata-galasa-isolated-tar.outputs.labels }}
-          build-args: |
-            directory=isolated/full
-          outputs: type=tar,dest=isolated/full/target/isolated/isolated.tar
+      - name: Manually build isolated.tar (full isolated)
+        run: |
+          docker pull ghcr.io/galasa-dev/galasa-isolated:main
+          docker save -o ${{ github.workspace }}/isolated/full/target/isolated/isolated.tar ghcr.io/galasa-dev/galasa-isolated:main
 
       - name: Build Isolated zip with maven
         working-directory: ./isolated/full
@@ -518,24 +504,10 @@ jobs:
           build-args: |
             directory=isolated/mvp
 
-      - name: Extract metadata for galasa-mvp-tar image
-        id: metadata-galasa-mvp-tar
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/galasa-mvp-tar
-
-      - name: Build Docker image for MVP tar file
-        id: build-galasa-mvp-tar
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ${{ github.workspace }}/isolated/dockerfiles/dockerfile.isolated
-          push: true
-          tags: ${{ steps.metadata-galasa-mvp-tar.outputs.tags }}
-          labels: ${{ steps.metadata-galasa-mvp-tar.outputs.labels }}
-          build-args: |
-            directory=isolated/mvp
-          outputs: type=tar,dest=isolated/mvp/target/isolated/isolated.tar
+      - name: Manually build isolated.tar (MVP)
+        run: |
+          docker pull ghcr.io/galasa-dev/galasa-mvp:main
+          docker save -o ${{ github.workspace }}/isolated/mvp/target/isolated/isolated.tar ghcr.io/galasa-dev/galasa-mvp:main
 
       - name: Build MVP zip with maven
         working-directory: ./isolated/mvp

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -215,27 +215,16 @@ jobs:
           context: .
           file: ${{ github.workspace }}/isolated/dockerfiles/dockerfile.isolated
           load: true
-          tags: galasa-isolated:test
+          tags: ghcr.io/galasa-dev/galasa-isolated:test
           build-args: |
             directory=isolated/full
 
-      # - name: Build Docker image for Isolated tar file
-      #   uses: docker/build-push-action@v5
-      #   with:
-      #     context: .
-      #     file: ${{ github.workspace }}/isolated/dockerfiles/dockerfile.isolated
-      #     load: true
-      #     tags: galasa-isolated-tar:test
-      #     build-args: |
-      #       directory=isolated/full
-      #     outputs: type=tar,dest=isolated/full/target/isolated/isolated.tar
-
-      - name: Manually build isolated.tar (Isolated)
+      - name: Build isolated.tar file (full isolated)
         run: |
-          docker pull ghcr.io/galasa-dev/galasa-mvp:main
-          docker save -o ${{ github.workspace }}/isolated/full/target/isolated/isolated.tar ghcr.io/galasa-dev/galasa-isolated:main
+          docker pull ghcr.io/galasa-dev/galasa-isolated:test
+          docker save -o ${{ github.workspace }}/isolated/full/target/isolated/isolated.tar ghcr.io/galasa-dev/galasa-isolated:test
 
-      - name: Upload isolated.tar (Isolated) for testing
+      - name: Upload isolated.tar (full isolated) for inspection
         uses: actions/upload-artifact@v4
         with:
           name: isolated.tar
@@ -476,25 +465,14 @@ jobs:
           context: .
           file: ${{ github.workspace }}/isolated/dockerfiles/dockerfile.isolated
           load: true
-          tags: galasa-mvp:test
+          tags: ghcr.io/galasa-dev/galasa-mvp:test
           build-args: |
             directory=isolated/mvp
 
-      # - name: Build Docker image for MVP tar file
-      #   uses: docker/build-push-action@v5
-      #   with:
-      #     context: .
-      #     file: ${{ github.workspace }}/isolated/dockerfiles/dockerfile.isolated
-      #     load: true
-      #     tags: galasa-mvp-tar:test
-      #     build-args: |
-      #       directory=isolated/mvp
-      #     outputs: type=tar,dest=isolated/mvp/target/isolated/isolated.tar
-
       - name: Manually build isolated.tar (MVP)
         run: |
-          docker pull ghcr.io/galasa-dev/galasa-mvp:main
-          docker save -o ${{ github.workspace }}/isolated/mvp/target/isolated/isolated.tar ghcr.io/galasa-dev/galasa-mvp:main
+          docker pull ghcr.io/galasa-dev/galasa-mvp:test
+          docker save -o ${{ github.workspace }}/isolated/mvp/target/isolated/isolated.tar ghcr.io/galasa-dev/galasa-mvp:test
 
       - name: Upload isolated.tar (MVP) for testing
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -221,8 +221,8 @@ jobs:
 
       - name: Build isolated.tar file (full isolated)
         run: |
-          docker pull ghcr.io/galasa-dev/galasa-isolated:test
-          docker save -o ${{ github.workspace }}/isolated/full/target/isolated/isolated.tar ghcr.io/galasa-dev/galasa-isolated:test
+          docker pull ghcr.io/galasa-dev/galasa-isolated:${{ github.event.number }}
+          docker save -o ${{ github.workspace }}/isolated/full/target/isolated/isolated.tar ghcr.io/galasa-dev/galasa-isolated:${{ github.event.number }}
 
       - name: Upload isolated.tar (full isolated) for inspection
         uses: actions/upload-artifact@v4
@@ -471,8 +471,8 @@ jobs:
 
       - name: Manually build isolated.tar (MVP)
         run: |
-          docker pull ghcr.io/galasa-dev/galasa-mvp:test
-          docker save -o ${{ github.workspace }}/isolated/mvp/target/isolated/isolated.tar ghcr.io/galasa-dev/galasa-mvp:test
+          docker pull ghcr.io/galasa-dev/galasa-mvp:${{ github.event.number }}
+          docker save -o ${{ github.workspace }}/isolated/mvp/target/isolated/isolated.tar ghcr.io/galasa-dev/galasa-mvp:${{ github.event.number }}
 
       - name: Upload isolated.tar (MVP) for testing
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -230,6 +230,12 @@ jobs:
             directory=isolated/full
           outputs: type=tar,dest=isolated/full/target/isolated/isolated.tar
 
+      - name: Upload isolated.tar (Isolated) for testing
+        uses: actions/upload-artifact@v4
+        with:
+          name: isolated.tar
+          path: ${{ github.workspace }}/isolated/full/target/isolated/isolated.tar
+
       - name: Build Isolated zip with maven
         working-directory: ./isolated/full
         run: |
@@ -479,6 +485,12 @@ jobs:
           build-args: |
             directory=isolated/mvp
           outputs: type=tar,dest=isolated/mvp/target/isolated/isolated.tar
+
+      - name: Upload isolated.tar (MVP) for testing
+        uses: actions/upload-artifact@v4
+        with:
+          name: mvp.tar
+          path: ${{ github.workspace }}/isolated/full/target/isolated/isolated.tar
 
       - name: Build MVP zip with maven
         working-directory: ./isolated/mvp

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -490,7 +490,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: mvp.tar
-          path: ${{ github.workspace }}/isolated/full/target/isolated/isolated.tar
+          path: ${{ github.workspace }}/isolated/mvp/target/isolated/isolated.tar
 
       - name: Build MVP zip with maven
         working-directory: ./isolated/mvp

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -232,6 +232,7 @@ jobs:
 
       - name: Manually build isolated.tar (Isolated)
         run: |
+          docker pull ghcr.io/galasa-dev/galasa-mvp:main
           docker save -o ${{ github.workspace }}/isolated/full/target/isolated/isolated.tar ghcr.io/galasa-dev/galasa-isolated:main
 
       - name: Upload isolated.tar (Isolated) for testing
@@ -492,6 +493,7 @@ jobs:
 
       - name: Manually build isolated.tar (MVP)
         run: |
+          docker pull ghcr.io/galasa-dev/galasa-mvp:main
           docker save -o ${{ github.workspace }}/isolated/mvp/target/isolated/isolated.tar ghcr.io/galasa-dev/galasa-mvp:main
 
       - name: Upload isolated.tar (MVP) for testing

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -219,16 +219,20 @@ jobs:
           build-args: |
             directory=isolated/full
 
-      - name: Build Docker image for Isolated tar file
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ${{ github.workspace }}/isolated/dockerfiles/dockerfile.isolated
-          load: true
-          tags: galasa-isolated-tar:test
-          build-args: |
-            directory=isolated/full
-          outputs: type=tar,dest=isolated/full/target/isolated/isolated.tar
+      # - name: Build Docker image for Isolated tar file
+      #   uses: docker/build-push-action@v5
+      #   with:
+      #     context: .
+      #     file: ${{ github.workspace }}/isolated/dockerfiles/dockerfile.isolated
+      #     load: true
+      #     tags: galasa-isolated-tar:test
+      #     build-args: |
+      #       directory=isolated/full
+      #     outputs: type=tar,dest=isolated/full/target/isolated/isolated.tar
+
+      - name: Manually build isolated.tar (Isolated)
+        run: |
+          docker save -o ${{ github.workspace }}/isolated/full/target/isolated/isolated.tar ghcr.io/galasa-dev/galasa-isolated:main
 
       - name: Upload isolated.tar (Isolated) for testing
         uses: actions/upload-artifact@v4
@@ -475,16 +479,20 @@ jobs:
           build-args: |
             directory=isolated/mvp
 
-      - name: Build Docker image for MVP tar file
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ${{ github.workspace }}/isolated/dockerfiles/dockerfile.isolated
-          load: true
-          tags: galasa-mvp-tar:test
-          build-args: |
-            directory=isolated/mvp
-          outputs: type=tar,dest=isolated/mvp/target/isolated/isolated.tar
+      # - name: Build Docker image for MVP tar file
+      #   uses: docker/build-push-action@v5
+      #   with:
+      #     context: .
+      #     file: ${{ github.workspace }}/isolated/dockerfiles/dockerfile.isolated
+      #     load: true
+      #     tags: galasa-mvp-tar:test
+      #     build-args: |
+      #       directory=isolated/mvp
+      #     outputs: type=tar,dest=isolated/mvp/target/isolated/isolated.tar
+
+      - name: Manually build isolated.tar (MVP)
+        run: |
+          docker save -o ${{ github.workspace }}/isolated/mvp/target/isolated/isolated.tar ghcr.io/galasa-dev/galasa-mvp:main
 
       - name: Upload isolated.tar (MVP) for testing
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -214,21 +214,10 @@ jobs:
         with:
           context: .
           file: ${{ github.workspace }}/isolated/dockerfiles/dockerfile.isolated
-          push: true
-          tags: ghcr.io/galasa-dev/galasa-isolated:${{ github.event.number }}
+          load: true
+          tags: galasa-isolated:test
           build-args: |
             directory=isolated/full
-
-      - name: Build isolated.tar file (full isolated)
-        run: |
-          docker pull ghcr.io/galasa-dev/galasa-isolated:${{ github.event.number }}
-          docker save -o ${{ github.workspace }}/isolated/full/target/isolated/isolated.tar ghcr.io/galasa-dev/galasa-isolated:${{ github.event.number }}
-
-      - name: Upload isolated.tar (full isolated) for inspection
-        uses: actions/upload-artifact@v4
-        with:
-          name: isolated.tar
-          path: ${{ github.workspace }}/isolated/full/target/isolated/isolated.tar
 
       - name: Build Isolated zip with maven
         working-directory: ./isolated/full
@@ -464,21 +453,10 @@ jobs:
         with:
           context: .
           file: ${{ github.workspace }}/isolated/dockerfiles/dockerfile.isolated
-          push: true
-          tags: ghcr.io/galasa-dev/galasa-mvp:${{ github.event.number }}
+          load: true
+          tags: galasa-mvp:test
           build-args: |
             directory=isolated/mvp
-
-      - name: Manually build isolated.tar (MVP)
-        run: |
-          docker pull ghcr.io/galasa-dev/galasa-mvp:${{ github.event.number }}
-          docker save -o ${{ github.workspace }}/isolated/mvp/target/isolated/isolated.tar ghcr.io/galasa-dev/galasa-mvp:${{ github.event.number }}
-
-      - name: Upload isolated.tar (MVP) for testing
-        uses: actions/upload-artifact@v4
-        with:
-          name: mvp.tar
-          path: ${{ github.workspace }}/isolated/mvp/target/isolated/isolated.tar
 
       - name: Build MVP zip with maven
         working-directory: ./isolated/mvp

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -214,8 +214,8 @@ jobs:
         with:
           context: .
           file: ${{ github.workspace }}/isolated/dockerfiles/dockerfile.isolated
-          load: true
-          tags: ghcr.io/galasa-dev/galasa-isolated:test
+          push: true
+          tags: ghcr.io/galasa-dev/galasa-isolated:${{ github.event.number }}
           build-args: |
             directory=isolated/full
 
@@ -464,8 +464,8 @@ jobs:
         with:
           context: .
           file: ${{ github.workspace }}/isolated/dockerfiles/dockerfile.isolated
-          load: true
-          tags: ghcr.io/galasa-dev/galasa-mvp:test
+          push: true
+          tags: ghcr.io/galasa-dev/galasa-mvp:${{ github.event.number }}
           build-args: |
             directory=isolated/mvp
 


### PR DESCRIPTION
## Why?

When doing some prerelease testing of the Isolated/MVP zip contents, by using the isolated.tar according to the instructions on galasa.dev, I found that the isolated.tar in both zips was broken. When you run `docker load -i isolated.tar` the response should say something like `Loaded image:...` but it said `open /var/lib/docker/tmp/docker-import-4172513240/bin/json: no such file or directory`.

From investigation in PR #85 I found that the isolated.tar is corrupted from the moment its built in the GH workflow - so the docker `build-push-action` must not be building it correctly.

This PR changes the build of the isolated.tar to use `docker save` which is simpler anyway and achieves the same thing, and builds an uncorrupted tar file (I've tested it locally against the galasa.dev instructions).

Note: discussion with @techcobweb decided we should not rename the isolated.tar for the MVP to mvp.tar as it might be confusing for users as all previous communication refers only to isolated.tar.