### PR TITLE
Remove selenium-opera-driver from isolated poms

### DIFF
--- a/full/pom.template
+++ b/full/pom.template
@@ -138,11 +138,6 @@
 		</dependency>
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
-			<artifactId>selenium-opera-driver</artifactId>
-			<type>jar</type>
-		</dependency>
-		<dependency>
-			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-remote-driver</artifactId>
 			<type>jar</type>
 		</dependency>

--- a/mvp/pom.template
+++ b/mvp/pom.template
@@ -138,11 +138,6 @@
 		</dependency>
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
-			<artifactId>selenium-opera-driver</artifactId>
-			<type>jar</type>
-		</dependency>
-		<dependency>
-			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-remote-driver</artifactId>
 			<type>jar</type>
 		</dependency>


### PR DESCRIPTION
## Why?
Related to changes in https://github.com/galasa-dev/galasa/pull/142

The `selenium-opera-driver` dependency was dropped since Selenium 4 no longer supports the Opera browser, so removing it from the isolated pom templates to fix build failures.