### PR TITLE
Move selenium jars out of pom.templates and add required parent poms to resolve selenium dependencies

### DIFF
--- a/build-locally.sh
+++ b/build-locally.sh
@@ -136,6 +136,8 @@ fi
 #-----------------------------------------------------------------------------------------
 # Main logic.
 #-----------------------------------------------------------------------------------------
+MVP_DISTRIBUTION="MVP"
+ISOLATED_DISTRIBUTION="Isolated"
 source_dir="."
 
 project=$(basename ${BASEDIR})
@@ -254,6 +256,16 @@ function generate_pom_xml {
 
     h2 "Generating the pom.xml from the pom.template for ${DISTRIBUTION}"
 
+    dist_flag=""
+    if [[ "${DISTRIBUTION}" == "${ISOLATED_DISTRIBUTION}" ]]; then
+        dist_flag="--isolated"
+    elif [[ "${DISTRIBUTION}" == "${MVP_DISTRIBUTION}" ]]; then
+        dist_flag="--mvp"
+    else
+        error "Programming logic error. Invalid distribution provided. Log file is ${log_file}"
+        exit 1
+    fi
+
     info "Using galasabld tool ${GALASA_BUILD_TOOL_PATH}"
 
     cmd="${GALASA_BUILD_TOOL_PATH} template \
@@ -263,7 +275,7 @@ function generate_pom_xml {
     --releaseMetadata ${WORKSPACE_DIR}/galasa/modules/obr/release.yaml \
     --template pom.template \
     --output pom.xml \
-    --isolated"
+    ${dist_flag}"
 
     echo "Command is $cmd" >> ${log_file}
     $cmd 2>&1 >> ${log_file}
@@ -454,33 +466,33 @@ rm -rf ${MVP_DIR}/bin
 # with information from several release.yaml files.
 get_galasabld_binary_location
 
-generate_pom_xml ${ISOLATED_DIR} "Isolated"
-build_pom_xml ${ISOLATED_DIR} "Isolated" "pom.xml" "target/isolated/maven"
-build_pom_xml ${ISOLATED_DIR} "Isolated" "pom2.xml" "target/isolated/maven"
-build_pom_xml ${ISOLATED_DIR} "Isolated" "pom3.xml" "target/isolated/maven"
-build_pom_xml ${ISOLATED_DIR} "Isolated" "pom4.xml" "target/isolated/maven"
-build_pom_xml ${ISOLATED_DIR} "Isolated" "pom5.xml" "target/isolated/maven"
-build_pom_xml ${ISOLATED_DIR} "Isolated" "pom6.xml" "target/isolated/maven"
-build_pom_xml ${ISOLATED_DIR} "Isolated" "pomJavaDoc.xml" "target/isolated"
-build_pom_xml ${ISOLATED_DIR} "Isolated" "pomDocs.xml" "target/isolated"
-build_pom_galasactl_xml ${ISOLATED_DIR} "Isolated"
-copy_text_files ${ISOLATED_DIR} "Isolated"
-build_zip ${ISOLATED_DIR} "Isolated"
+generate_pom_xml ${ISOLATED_DIR} ${ISOLATED_DISTRIBUTION}
+build_pom_xml ${ISOLATED_DIR} ${ISOLATED_DISTRIBUTION} "pom.xml" "target/isolated/maven"
+build_pom_xml ${ISOLATED_DIR} ${ISOLATED_DISTRIBUTION} "pom2.xml" "target/isolated/maven"
+build_pom_xml ${ISOLATED_DIR} ${ISOLATED_DISTRIBUTION} "pom3.xml" "target/isolated/maven"
+build_pom_xml ${ISOLATED_DIR} ${ISOLATED_DISTRIBUTION} "pom4.xml" "target/isolated/maven"
+build_pom_xml ${ISOLATED_DIR} ${ISOLATED_DISTRIBUTION} "pom5.xml" "target/isolated/maven"
+build_pom_xml ${ISOLATED_DIR} ${ISOLATED_DISTRIBUTION} "pom6.xml" "target/isolated/maven"
+build_pom_xml ${ISOLATED_DIR} ${ISOLATED_DISTRIBUTION} "pomJavaDoc.xml" "target/isolated"
+build_pom_xml ${ISOLATED_DIR} ${ISOLATED_DISTRIBUTION} "pomDocs.xml" "target/isolated"
+build_pom_galasactl_xml ${ISOLATED_DIR} ${ISOLATED_DISTRIBUTION}
+copy_text_files ${ISOLATED_DIR} ${ISOLATED_DISTRIBUTION}
+build_zip ${ISOLATED_DIR} ${ISOLATED_DISTRIBUTION}
 
 success "Galasa Isolated distribution built successfully - the result can be found at ${ISOLATED_DIR}/target/isolated."
 
-generate_pom_xml ${MVP_DIR} "MVP"
-build_pom_xml ${MVP_DIR} "MVP" "pom.xml" "target/isolated/maven"
-build_pom_xml ${MVP_DIR} "MVP" "pom2.xml" "target/isolated/maven"
-build_pom_xml ${MVP_DIR} "MVP" "pom3.xml" "target/isolated/maven"
-build_pom_xml ${MVP_DIR} "MVP" "pom4.xml" "target/isolated/maven"
-build_pom_xml ${MVP_DIR} "MVP" "pom5.xml" "target/isolated/maven"
-build_pom_xml ${MVP_DIR} "MVP" "pom6.xml" "target/isolated/maven"
-build_pom_xml ${MVP_DIR} "MVP" "pomJavaDoc.xml" "target/isolated"
-build_pom_xml ${MVP_DIR} "MVP" "pomDocs.xml" "target/isolated"
-build_pom_galasactl_xml ${MVP_DIR} "MVP"
-copy_text_files ${MVP_DIR} "MVP"
-build_zip ${MVP_DIR} "MVP"
+generate_pom_xml ${MVP_DIR} ${MVP_DISTRIBUTION}
+build_pom_xml ${MVP_DIR} ${MVP_DISTRIBUTION} "pom.xml" "target/isolated/maven"
+build_pom_xml ${MVP_DIR} ${MVP_DISTRIBUTION} "pom2.xml" "target/isolated/maven"
+build_pom_xml ${MVP_DIR} ${MVP_DISTRIBUTION} "pom3.xml" "target/isolated/maven"
+build_pom_xml ${MVP_DIR} ${MVP_DISTRIBUTION} "pom4.xml" "target/isolated/maven"
+build_pom_xml ${MVP_DIR} ${MVP_DISTRIBUTION} "pom5.xml" "target/isolated/maven"
+build_pom_xml ${MVP_DIR} ${MVP_DISTRIBUTION} "pom6.xml" "target/isolated/maven"
+build_pom_xml ${MVP_DIR} ${MVP_DISTRIBUTION} "pomJavaDoc.xml" "target/isolated"
+build_pom_xml ${MVP_DIR} ${MVP_DISTRIBUTION} "pomDocs.xml" "target/isolated"
+build_pom_galasactl_xml ${MVP_DIR} ${MVP_DISTRIBUTION}
+copy_text_files ${MVP_DIR} ${MVP_DISTRIBUTION}
+build_zip ${MVP_DIR} ${MVP_DISTRIBUTION}
 
 success "Galasa MVP distribution built successfully - the result can be found at ${MVP_DIR}/target/isolated."
 

--- a/full/pom.template
+++ b/full/pom.template
@@ -111,37 +111,27 @@
 			<type>pom</type>
 		</dependency>
 
-		<dependency>
-			<groupId>org.seleniumhq.selenium</groupId>
-			<artifactId>selenium-api</artifactId>
-			<type>jar</type>
-		</dependency>
-		<dependency>
-			<groupId>org.seleniumhq.selenium</groupId>
-			<artifactId>selenium-ie-driver</artifactId>
-			<type>jar</type>
-		</dependency>
-		<dependency>
-			<groupId>org.seleniumhq.selenium</groupId>
-			<artifactId>selenium-edge-driver</artifactId>
-			<type>jar</type>
-		</dependency>
-		<dependency>
-			<groupId>org.seleniumhq.selenium</groupId>
-			<artifactId>selenium-chrome-driver</artifactId>
-			<type>jar</type>
-		</dependency>
-		<dependency>
-			<groupId>org.seleniumhq.selenium</groupId>
-			<artifactId>selenium-firefox-driver</artifactId>
-			<type>jar</type>
-		</dependency>
-		<dependency>
-			<groupId>org.seleniumhq.selenium</groupId>
-			<artifactId>selenium-remote-driver</artifactId>
-			<type>jar</type>
-		</dependency>
-
+        <!-- 
+            The following are required to resolve transitive dependencies for the selenium manager
+        -->
+        <dependency>
+            <groupId>com.google.auto.service</groupId>
+            <artifactId>auto-service-aggregator</artifactId>
+            <version>1.1.1</version>
+            <type>pom</type>
+        </dependency>
+        <dependency>
+            <groupId>dev.failsafe</groupId>
+            <artifactId>failsafe-parent</artifactId>
+            <version>3.3.2</version>
+            <type>pom</type>
+        </dependency>
+        <dependency>
+            <groupId>org.sonatype.oss</groupId>
+            <artifactId>oss-parent</artifactId>
+            <version>7</version>
+            <type>pom</type>
+        </dependency>
 	</dependencies>
 
 	<build>

--- a/mvp/pom.template
+++ b/mvp/pom.template
@@ -111,36 +111,27 @@
 			<type>pom</type>
 		</dependency>
 
-		<dependency>
-			<groupId>org.seleniumhq.selenium</groupId>
-			<artifactId>selenium-api</artifactId>
-			<type>jar</type>
-		</dependency>
-		<dependency>
-			<groupId>org.seleniumhq.selenium</groupId>
-			<artifactId>selenium-ie-driver</artifactId>
-			<type>jar</type>
-		</dependency>
-		<dependency>
-			<groupId>org.seleniumhq.selenium</groupId>
-			<artifactId>selenium-edge-driver</artifactId>
-			<type>jar</type>
-		</dependency>
-		<dependency>
-			<groupId>org.seleniumhq.selenium</groupId>
-			<artifactId>selenium-chrome-driver</artifactId>
-			<type>jar</type>
-		</dependency>
-		<dependency>
-			<groupId>org.seleniumhq.selenium</groupId>
-			<artifactId>selenium-firefox-driver</artifactId>
-			<type>jar</type>
-		</dependency>
-		<dependency>
-			<groupId>org.seleniumhq.selenium</groupId>
-			<artifactId>selenium-remote-driver</artifactId>
-			<type>jar</type>
-		</dependency>
+        <!-- 
+            The following are required to resolve transitive dependencies for the selenium manager
+        -->
+        <dependency>
+            <groupId>com.google.auto.service</groupId>
+            <artifactId>auto-service-aggregator</artifactId>
+            <version>1.1.1</version>
+            <type>pom</type>
+        </dependency>
+        <dependency>
+            <groupId>dev.failsafe</groupId>
+            <artifactId>failsafe-parent</artifactId>
+            <version>3.3.2</version>
+            <type>pom</type>
+        </dependency>
+        <dependency>
+            <groupId>org.sonatype.oss</groupId>
+            <artifactId>oss-parent</artifactId>
+            <version>7</version>
+            <type>pom</type>
+        </dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
## Why?
Related to changes in https://github.com/galasa-dev/galasa/pull/146

## Changes
- Moved the selenium jars out from the pom.templates and into the OBR release.yaml
- Added parent pom dependencies required for resolving transitive dependencies of selenium (auto-service-annotations:1.1.1 and failsafe:3.3.2)
- Fixed the build-locally script so it generates the correct pom.xml using the `--mvp` flag for MVP instead of `--isolated` for both