### PR TITLE
Iss2054 - Upgrade assertj-core version

### DIFF
--- a/full/pom2.xml
+++ b/full/pom2.xml
@@ -44,22 +44,6 @@
 			<version>10</version>
 			<type>pom</type>
 		</dependency>
-
-        <!--
-            The following POMs are used to resolve assertj-core:3.11.1
-        -->
-		<dependency>
-			<groupId>org.assertj</groupId>
-			<artifactId>assertj-parent-pom</artifactId>
-			<version>2.2.1</version>
-			<type>pom</type>
-		</dependency>
-		<dependency>
-			<groupId>org.junit</groupId>
-			<artifactId>junit-bom</artifactId>
-			<version>5.2.0</version>
-			<type>pom</type>
-		</dependency>
 	</dependencies>
 
 	<build>

--- a/mvp/pom2.xml
+++ b/mvp/pom2.xml
@@ -44,22 +44,6 @@
 			<version>10</version>
 			<type>pom</type>
 		</dependency>
-
-        <!--
-            The following POMs are used to resolve assertj-core:3.11.1
-        -->
-		<dependency>
-			<groupId>org.assertj</groupId>
-			<artifactId>assertj-parent-pom</artifactId>
-			<version>2.2.1</version>
-			<type>pom</type>
-		</dependency>
-		<dependency>
-			<groupId>org.junit</groupId>
-			<artifactId>junit-bom</artifactId>
-			<version>5.2.0</version>
-			<type>pom</type>
-		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2054

- Remove POMs used to resolve assertj-core 3.11.1 as we have now upgraded to using assertj-core 3.25.3