### PR TITLE
Add byte-buddy-parent to the zips

### DIFF
--- a/full/pom2.xml
+++ b/full/pom2.xml
@@ -44,6 +44,15 @@
 			<version>10</version>
 			<type>pom</type>
 		</dependency>
+
+
+		<!-- Needed to resolve net.bytebuddy:byte-buddy:3.25.3 -->
+		<dependency>
+			<groupId>net.bytebuddy</groupId>
+			<artifactId>byte-buddy-parent</artifactId>
+			<version>1.15.10</version>
+			<type>pom</type>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/mvp/pom2.xml
+++ b/mvp/pom2.xml
@@ -44,6 +44,15 @@
 			<version>10</version>
 			<type>pom</type>
 		</dependency>
+
+
+		<!-- Needed to resolve net.bytebuddy:byte-buddy:3.25.3 -->
+		<dependency>
+			<groupId>net.bytebuddy</groupId>
+			<artifactId>byte-buddy-parent</artifactId>
+			<version>1.15.10</version>
+			<type>pom</type>
+		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
## Why?

Adding byte-buddy to the Isolates/MVP zip now requires the parent POM byte-buddy-parent to also be included.