### PR TITLE
Iss2190 - Add Isolated/MVP tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,6 +22,9 @@ jobs:
     # This variable can be referenced by other jobs in this flow using ${{ needs.get-galasa-version.outputs.galasa-version }}
     runs-on: macos-latest
 
+    # Skip this testing workflow if this repository is a fork.
+    if: ${{ github.repository_owner == 'galasa-dev' }}
+
     steps:
       - name: Checkout 'galasa' repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2190

This PR adds a new GitHub Actions workflow that is scheduled as part of the daily regression run, and can be run at will for miscellaneous testing/release testing. 

The workflow downloads the Isolated zip, extracts its contents, makes the provided `galasactl` binary executable, initialises a local Galasa environment with that binary, then runs a handful of tests locally with the binary, using only the contents of the zip. It does the same with the MVP zip.

This is intended to test that tests can run using just the Isolated/MVP zip contents for Galasa users who are offline. This workflow is intended to replace the old inttests of type *Isolated and *Mvp (other than the Z ones, as they cannot be tested in GH Actions).