### PR TITLE
Update galasa.docs.repo location

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -84,7 +84,7 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
+          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-pom.log
@@ -98,7 +98,7 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
+          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-pom2.log
@@ -112,7 +112,7 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
+          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-pom3.log
@@ -126,7 +126,7 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
+          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-pom4.log
@@ -140,7 +140,7 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
+          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-pom5.log
@@ -154,7 +154,7 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
+          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-pom6.log
@@ -168,7 +168,7 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
+          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-javadoc.log
@@ -185,7 +185,7 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
+          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           -Dgithub.token.read.packages.username=${{ env.GITHUB_TOKEN_READ_PACKAGES_USERNAME }} \
           -Dgithub.token.read.packages.password=${{ env.GITHUB_TOKEN_READ_PACKAGES_PASSWORD }} \
@@ -214,7 +214,7 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
+          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-galasactl.log
@@ -267,7 +267,7 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
+          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-zip.log
@@ -367,7 +367,7 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
+          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-pom.log
@@ -381,7 +381,7 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
+          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-pom2.log
@@ -395,7 +395,7 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
+          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-pom3.log
@@ -409,7 +409,7 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
+          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-pom4.log
@@ -423,7 +423,7 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
+          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-pom5.log
@@ -437,7 +437,7 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
+          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-pom6.log
@@ -451,7 +451,7 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
+          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-javadoc.log
@@ -468,7 +468,7 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
+          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           -Dgithub.token.read.packages.username=${{ env.GITHUB_TOKEN_READ_PACKAGES_USERNAME }} \
           -Dgithub.token.read.packages.password=${{ env.GITHUB_TOKEN_READ_PACKAGES_PASSWORD }} \
@@ -497,7 +497,7 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
+          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-galasactl.log
@@ -550,7 +550,7 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
+          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-zip.log

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -62,7 +62,7 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
+          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-pom.log
@@ -77,7 +77,7 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
+          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-pom2.log
@@ -92,7 +92,7 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
+          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-pom3.log
@@ -107,7 +107,7 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
+          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-pom4.log
@@ -122,7 +122,7 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
+          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-pom5.log
@@ -137,7 +137,7 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
+          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-pom6.log
@@ -152,7 +152,7 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
+          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-javadoc.log
@@ -172,7 +172,7 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
+          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           -Dgithub.token.read.packages.username=${{ env.GITHUB_TOKEN_READ_PACKAGES_USERNAME }} \
           -Dgithub.token.read.packages.password=${{ env.GITHUB_TOKEN_READ_PACKAGES_PASSWORD }} \
@@ -202,7 +202,7 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
+          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-galasactl.log
@@ -233,7 +233,7 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
+          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-zip.log
@@ -305,7 +305,7 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
+          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-pom.log
@@ -320,7 +320,7 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
+          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-pom2.log
@@ -335,7 +335,7 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
+          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-pom3.log
@@ -350,7 +350,7 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
+          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-pom4.log
@@ -365,7 +365,7 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
+          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-pom5.log
@@ -380,7 +380,7 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
+          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-pom6.log
@@ -395,7 +395,7 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
+          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-javadoc.log
@@ -415,7 +415,7 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
+          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           -Dgithub.token.read.packages.username=${{ env.GITHUB_TOKEN_READ_PACKAGES_USERNAME }} \
           -Dgithub.token.read.packages.password=${{ env.GITHUB_TOKEN_READ_PACKAGES_PASSWORD }} \
@@ -445,7 +445,7 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
+          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-galasactl.log
@@ -476,7 +476,7 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
+          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-zip.log

--- a/build-locally.sh
+++ b/build-locally.sh
@@ -306,7 +306,7 @@ function build_pom_xml {
     -Dgalasa.runtime.repo=${SOURCE_MAVEN_OBR} \
     -Dgalasa.simplatform.repo=${SOURCE_MAVEN_SIMPLATFORM} \
     -Dgalasa.javadoc.repo=${SOURCE_MAVEN_JAVADOC} \
-    -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
+    -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
     -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
     -Dgithub.token.read.packages.username=${GITHUB_USERNAME} \
     -Dgithub.token.read.packages.password=${GITHUB_TOKEN} \
@@ -346,7 +346,7 @@ function build_pom_galasactl_xml {
     -Dgalasa.runtime.repo=${SOURCE_MAVEN_OBR} \
     -Dgalasa.simplatform.repo=${SOURCE_MAVEN_SIMPLATFORM} \
     -Dgalasa.javadoc.repo=${SOURCE_MAVEN_JAVADOC} \
-    -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
+    -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
     -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
     -Dgithub.token.read.packages.username=${GITHUB_USERNAME} \
     -Dgithub.token.read.packages.password=${GITHUB_TOKEN} \
@@ -398,7 +398,7 @@ function build_zip {
     -Dgalasa.runtime.repo=${SOURCE_MAVEN_OBR} \
     -Dgalasa.simplatform.repo=${SOURCE_MAVEN_SIMPLATFORM} \
     -Dgalasa.javadoc.repo=${SOURCE_MAVEN_JAVADOC} \
-    -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev/galasa.dev \
+    -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
     -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
     -Dgithub.token.read.packages.username=${GITHUB_USERNAME} \
     -Dgithub.token.read.packages.password=${GITHUB_TOKEN} \


### PR DESCRIPTION
## Why?

Update galasa.docs.repo location, as now the old docs repo, galasa.dev, has been moved to the organisation galasa-dev-archives, this location to download the galasa-www-isolated jar is incorrect. 