### PR TITLE
Fix to Isolated build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -51,7 +51,7 @@ jobs:
           REPO: https://github.com/galasa-dev/galasa
         run: |
           WORKFLOW_NAME="Main Build Orchestrator"
-          if [ "${{ env.BRANCH }}" = "release" ]; then
+          if [ "${{ env.BRANCH }}" = "release" ] || [ "${{ env.BRANCH }}" = "prerelease" ]; then
             WORKFLOW_NAME="Release Build Orchestrator"
           fi
 


### PR DESCRIPTION
## Why? 

The step `find-last-successful-build` uses the `gh` CLI to find the last successful workflow from which it can download the galasa-docs-site HTML. If this is a Main build then it should look for the last successful run of Main Build Orchestrator, if its a prerelease or release build, then it should look for Release Build Orchestrator. 

This PR fixes a missing check in this step for if the branch is prerelease. As is, the prerelease build of the workflow would return null for the step output and then not be able to download galasa-docs-site from anywhere.