### PR TITLE
Iss2369 - Update biz.aQute.bnd.builder.gradle.plugin to version compatible with Gradle 9.0

### DIFF
--- a/full/pom5.xml
+++ b/full/pom5.xml
@@ -50,6 +50,9 @@
 		<dependency>
 			<groupId>biz.aQute.bnd.builder</groupId>
 			<artifactId>biz.aQute.bnd.builder.gradle.plugin</artifactId>
+			<!-- Must now explicitly set version as cannot use the platform for other BOM artifacts -->
+			<version>7.1.0</version> 
+			<type>pom</type>
 		</dependency>
 
         <!--

--- a/mvp/pom5.xml
+++ b/mvp/pom5.xml
@@ -50,6 +50,9 @@
 		<dependency>
 			<groupId>biz.aQute.bnd.builder</groupId>
 			<artifactId>biz.aQute.bnd.builder.gradle.plugin</artifactId>
+			<!-- Must now explicitly set version as cannot use the platform for other BOM artifacts -->
+			<version>7.1.0</version> 
+			<type>pom</type>
 		</dependency>
 
         <!--


### PR DESCRIPTION
## Why?

This change is required due to https://github.com/galasa-dev/webui/pull/198

Build failures have started since the changes for the Gradle 9.0 uplift were merged (https://github.com/galasa-dev/isolated/actions/runs/17292555301)

## Changes

- Update biz.aQute.bnd.builder.gradle.plugin dependency version to 7.1.0 - following the Gradle uplift, this is the compatible version of the plugin with Gradle 9
- Update biz.aQute.bnd.builder.gradle.plugin dependency to POM type as it is now no longer a JAR and is just a BOM (see [Maven Central](https://repo.maven.apache.org/maven2/biz/aQute/bnd/builder/biz.aQute.bnd.builder.gradle.plugin/7.1.0/))
