### PR TITLE
Remove references to galasa.docs.repo for the old galasa.dev documentation site

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,7 +34,6 @@ jobs:
       check_read_github_packages_token: 'true'
     secrets:
       WRITE_GITHUB_PACKAGES_TOKEN: ${{ secrets.WRITE_GITHUB_PACKAGES_TOKEN }}
-      READ_GITHUB_PACKAGES_TOKEN: ${{ secrets.READ_GITHUB_PACKAGES_TOKEN }}
 
   find-last-successful-build:
     name: Find last successful Galasa build to download galasa-docs-site from
@@ -113,7 +112,6 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-pom.log
@@ -127,7 +125,6 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-pom2.log
@@ -141,7 +138,6 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-pom3.log
@@ -155,7 +151,6 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-pom4.log
@@ -169,7 +164,6 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-pom5.log
@@ -183,7 +177,6 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-pom6.log
@@ -197,7 +190,6 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-javadoc.log
@@ -224,7 +216,6 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-galasactl.log
@@ -291,7 +282,6 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-zip.log
@@ -413,7 +403,6 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-pom.log
@@ -427,7 +416,6 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-pom2.log
@@ -441,7 +429,6 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-pom3.log
@@ -455,7 +442,6 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-pom4.log
@@ -469,7 +455,6 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-pom5.log
@@ -483,7 +468,6 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-pom6.log
@@ -497,7 +481,6 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-javadoc.log
@@ -524,7 +507,6 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-galasactl.log
@@ -591,7 +573,6 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/${{ env.BRANCH }}/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-zip.log

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -85,7 +85,6 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-pom.log
@@ -100,7 +99,6 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-pom2.log
@@ -115,7 +113,6 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-pom3.log
@@ -130,7 +127,6 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-pom4.log
@@ -145,7 +141,6 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-pom5.log
@@ -160,7 +155,6 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-pom6.log
@@ -175,7 +169,6 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-javadoc.log
@@ -203,7 +196,6 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-galasactl.log
@@ -243,7 +235,6 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee isolated-build-logs/build-isolated-zip.log
@@ -316,7 +307,6 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-pom.log
@@ -331,7 +321,6 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-pom2.log
@@ -346,7 +335,6 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-pom3.log
@@ -361,7 +349,6 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-pom4.log
@@ -376,7 +363,6 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-pom5.log
@@ -391,7 +377,6 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-pom6.log
@@ -406,7 +391,6 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-javadoc.log
@@ -434,7 +418,6 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-galasactl.log
@@ -465,7 +448,6 @@ jobs:
           -Dgalasa.runtime.repo=https://development.galasa.dev/main/maven-repo/obr \
           -Dgalasa.simplatform.repo=https://development.galasa.dev/main/maven-repo/simplatform \
           -Dgalasa.javadoc.repo=https://development.galasa.dev/main/maven-repo/javadoc \
-          -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
           -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
           --batch-mode --errors --fail-at-end \
           --settings ${{ github.workspace }}/isolated/settings.xml 2>&1 | tee mvp-build-logs/build-mvp-zip.log

--- a/build-locally.sh
+++ b/build-locally.sh
@@ -62,18 +62,6 @@ Options are:
 -h | --help : Display this help text
 
 Environment Variables:
-GITHUB_USERNAME :
-    Mandatory.
-    A GitHub username with an associated Personal Acccess Token with access scope
-    to read from GitHub Packages. Needed to read the Galasa docs which are stored
-    in GitHub Packages.
-
-GITHUB_TOKEN :
-    Mandatory.
-    A GitHub Personal Access Token with read:packages scope to read from GitHub
-    Packages. Needed to read the Galasa docs which are stored in GitHub Packages.
-    The token must be for the user set in GITHUB_USERNAME.
-
 SOURCE_MAVEN_OBR :
     Optional. Defaults to https://development.galasa.dev/main/maven-repo/obr
     Used to indicate where the Galasa OBR artifacts can be found.
@@ -120,18 +108,6 @@ while [ "$1" != "" ]; do
     esac
     shift
 done
-
-if [[ -z $GITHUB_USERNAME ]]; then
-    error "Environment variable GITHUB_USERNAME needs to be set."
-    usage
-    exit 1
-fi
-
-if [[ -z $GITHUB_TOKEN ]]; then
-    error "Environment variable GITHUB_TOKEN needs to be set."
-    usage
-    exit 1
-fi
 
 #-----------------------------------------------------------------------------------------
 # Main logic.
@@ -306,10 +282,7 @@ function build_pom_xml {
     -Dgalasa.runtime.repo=${SOURCE_MAVEN_OBR} \
     -Dgalasa.simplatform.repo=${SOURCE_MAVEN_SIMPLATFORM} \
     -Dgalasa.javadoc.repo=${SOURCE_MAVEN_JAVADOC} \
-    -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
     -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
-    -Dgithub.token.read.packages.username=${GITHUB_USERNAME} \
-    -Dgithub.token.read.packages.password=${GITHUB_TOKEN} \
     --batch-mode --errors --fail-at-end \
     --settings ${BASEDIR}/settings.xml"
 
@@ -346,10 +319,7 @@ function build_pom_galasactl_xml {
     -Dgalasa.runtime.repo=${SOURCE_MAVEN_OBR} \
     -Dgalasa.simplatform.repo=${SOURCE_MAVEN_SIMPLATFORM} \
     -Dgalasa.javadoc.repo=${SOURCE_MAVEN_JAVADOC} \
-    -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
     -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
-    -Dgithub.token.read.packages.username=${GITHUB_USERNAME} \
-    -Dgithub.token.read.packages.password=${GITHUB_TOKEN} \
     --batch-mode --errors --fail-at-end \
     --settings ${BASEDIR}/settings.xml"
 
@@ -398,10 +368,7 @@ function build_zip {
     -Dgalasa.runtime.repo=${SOURCE_MAVEN_OBR} \
     -Dgalasa.simplatform.repo=${SOURCE_MAVEN_SIMPLATFORM} \
     -Dgalasa.javadoc.repo=${SOURCE_MAVEN_JAVADOC} \
-    -Dgalasa.docs.repo=https://maven.pkg.github.com/galasa-dev-archives/galasa.dev \
     -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
-    -Dgithub.token.read.packages.username=${GITHUB_USERNAME} \
-    -Dgithub.token.read.packages.password=${GITHUB_TOKEN} \
     --batch-mode --errors --fail-at-end \
     --settings ${BASEDIR}/settings.xml"
 

--- a/settings.xml
+++ b/settings.xml
@@ -23,10 +23,6 @@
                     <url>${galasa.javadoc.repo}</url>
                 </repository>
                 <repository>
-                    <id>galasa.docs.repo</id>
-                    <url>${galasa.docs.repo}</url>
-                </repository>
-                <repository>
                     <id>central</id>
                     <url>${galasa.central.repo}</url>
                 </repository>
@@ -43,12 +39,5 @@
             </pluginRepositories>
         </profile>
 	</profiles>
-    <servers>
-        <server>
-            <id>galasa.docs.repo</id>
-            <username>${github.token.read.packages.username}</username>
-            <password>${github.token.read.packages.password}</password>
-        </server>
-    </servers>
 
 </settings>


### PR DESCRIPTION
## Why?

The Isolated builds no longer need to point at the `galasa.docs.repo` location as this contains the archived documentation site which is not updated anymore. This means that the `READ_GITHUB_PACKAGES_TOKEN` is no longer needed in the remote builds and `GITHUB_USERNAME` and `GITHUB_TOKEN` are no longer needed in the build-locally.sh script.