### PR TITLE
Generated pom.xmls made with galasabld template can list dependency exclusions

### DIFF
--- a/full/pom.template
+++ b/full/pom.template
@@ -85,12 +85,19 @@
         <dependency>
             <groupId>{{.GroupId}}</groupId>
             <artifactId>{{.ArtifactId}}</artifactId>{{if .Version}}
-            <version>{{.Version}}</version>{{end}}
+            <version>{{.Version}}</version>{{end}}{{if .Exclusions}}
+            <exclusions>{{range .Exclusions}}
+                <exclusion>
+                    <groupId>{{.GroupId}}</groupId>
+                    <artifactId>{{.ArtifactId}}</artifactId>
+                </exclusion>{{end}}
+            </exclusions>{{end}}
         </dependency>
     {{end}}
 
         <!--
-            To resolve commons-logging:1.3.4, commons-parent:72 and org.apache:33 are required.
+            Required to resolve commons-logging:1.3.4 — commons-parent:72 is its parent POM,
+            and org.apache:33 is the parent of commons-parent.
         -->
 		<dependency>
 			<groupId>org.apache.commons</groupId>
@@ -104,6 +111,11 @@
 			<version>33</version>
 			<type>pom</type>
 		</dependency>
+
+        <!--
+            Required to resolve org.junit.jupiter:junit-jupiter and related JUnit 5 artifacts
+            pulled in transitively by the test managers.
+        -->
 		<dependency>
 			<groupId>org.junit</groupId>
 			<artifactId>junit-bom</artifactId>
@@ -111,8 +123,11 @@
 			<type>pom</type>
 		</dependency>
 
-        <!-- 
-            The following are required to resolve transitive dependencies for the selenium manager
+        <!--
+            Required to resolve transitive dependencies for the selenium manager:
+            - auto-service-aggregator is the parent POM for com.google.auto.service:auto-service-annotations
+            - failsafe-parent is the parent POM for dev.failsafe:failsafe
+            - oss-parent is a transitive parent POM required by several selenium dependencies
         -->
         <dependency>
             <groupId>com.google.auto.service</groupId>

--- a/mvp/pom.template
+++ b/mvp/pom.template
@@ -85,12 +85,19 @@
         <dependency>
             <groupId>{{.GroupId}}</groupId>
             <artifactId>{{.ArtifactId}}</artifactId>{{if .Version}}
-            <version>{{.Version}}</version>{{end}}
+            <version>{{.Version}}</version>{{end}}{{if .Exclusions}}
+            <exclusions>{{range .Exclusions}}
+                <exclusion>
+                    <groupId>{{.GroupId}}</groupId>
+                    <artifactId>{{.ArtifactId}}</artifactId>
+                </exclusion>{{end}}
+            </exclusions>{{end}}
         </dependency>
     {{end}}
 
         <!--
-            To resolve commons-logging:1.3.4, commons-parent:72 and org.apache:33 are required.
+            Required to resolve commons-logging:1.3.4 — commons-parent:72 is its parent POM,
+            and org.apache:33 is the parent of commons-parent.
         -->
 		<dependency>
 			<groupId>org.apache.commons</groupId>
@@ -104,6 +111,11 @@
 			<version>33</version>
 			<type>pom</type>
 		</dependency>
+
+        <!--
+            Required to resolve org.junit.jupiter:junit-jupiter and related JUnit 5 artifacts
+            pulled in transitively by the test managers.
+        -->
 		<dependency>
 			<groupId>org.junit</groupId>
 			<artifactId>junit-bom</artifactId>
@@ -111,8 +123,11 @@
 			<type>pom</type>
 		</dependency>
 
-        <!-- 
-            The following are required to resolve transitive dependencies for the selenium manager
+        <!--
+            Required to resolve transitive dependencies for the selenium manager:
+            - auto-service-aggregator is the parent POM for com.google.auto.service:auto-service-annotations
+            - failsafe-parent is the parent POM for dev.failsafe:failsafe
+            - oss-parent is a transitive parent POM required by several selenium dependencies
         -->
         <dependency>
             <groupId>com.google.auto.service</groupId>


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/2608

This PR builds on changes made in https://github.com/galasa-dev/galasa/pull/656

This PR includes an update to the pom.template for Isolated and MVP so that `<exclusions>` blocks are conditionally included for certain dependencies in generated pom.xml files, if listed in the release.yaml. This will make it easier going forward to exclude vulnerable transitive dependencies from generated pom.xmls for the Isolated/MVP.

This PR also includes more detailed comments about the explicit direct dependencies left in the pom.xmls to make it easier to simplify or maintain in future.

Changes
- [x] Updates to Go template pom.template for Isolated and MVP to be able to include `<exclusions>` if present in the release.yaml which is processed by `galasabld template`
- [x] Improved comments about the remaining explicit dependencies